### PR TITLE
roi_gop300_c34 submission

### DIFF
--- a/submissions/roi_gop300_c34/compress.sh
+++ b/submissions/roi_gop300_c34/compress.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PD="$(cd "${HERE}/../.." && pwd)"
+TMP_DIR="${PD}/tmp/roi_gop300_c34"
+
+IN_DIR="${PD}/videos"
+VIDEO_NAMES_FILE="${PD}/public_test_video_names.txt"
+ARCHIVE_DIR="${HERE}/archive"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in-dir|--in_dir) IN_DIR="${2%/}"; shift 2 ;;
+    --video-names-file|--video_names_file) VIDEO_NAMES_FILE="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+rm -rf "$ARCHIVE_DIR"
+mkdir -p "$ARCHIVE_DIR" "$TMP_DIR"
+rm -f "${HERE}/archive.zip"
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  IN="${IN_DIR}/${line}"
+  BASE="${line%.*}"
+  OUT="${ARCHIVE_DIR}/${BASE}.mkv"
+  PRE="${TMP_DIR}/${BASE}.pre.mkv"
+
+  echo "→ ${IN} → ${OUT}"
+
+  # ROI preprocessing: denoise outside driving corridor
+  python "${HERE}/roi_preprocess.py" \
+    --input "$IN" \
+    --output "$PRE" \
+    --outside-luma-denoise 2.5 \
+    --outside-chroma-mode medium \
+    --feather-radius 48 \
+    --outside-blend 0.60
+
+  # Encode with SVT-AV1: CRF 34, scale 0.45, GOP 300, film-grain 22
+  ffmpeg -nostdin -y -hide_banner -loglevel warning \
+    -r 20 -fflags +genpts -i "$PRE" \
+    -vf "scale=trunc(iw*0.45/2)*2:trunc(ih*0.45/2)*2:flags=lanczos" \
+    -pix_fmt yuv420p -c:v libsvtav1 -preset 0 -crf 34 \
+    -svtav1-params "film-grain=22:keyint=300:scd=0:enable-qm=1:qm-min=0" \
+    -r 20 "$OUT"
+
+  rm -f "$PRE"
+done < "$VIDEO_NAMES_FILE"
+
+cd "$ARCHIVE_DIR"
+zip -r "${HERE}/archive.zip" .
+echo "Compressed to ${HERE}/archive.zip"

--- a/submissions/roi_gop300_c34/inflate.py
+++ b/submissions/roi_gop300_c34/inflate.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import os, sys, torch
+import torch.nn.functional as F
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+from frame_utils import camera_size, yuv420_to_rgb
+import av
+
+
+def decode_and_resize_to_file(video_path, dst):
+    target_w, target_h = camera_size
+    container = av.open(video_path)
+    stream = container.streams.video[0]
+    n = 0
+    with open(dst, "wb") as f:
+        for frame in container.decode(stream):
+            t = yuv420_to_rgb(frame)
+            h, w, _ = t.shape
+            if h != target_h or w != target_w:
+                x = t.permute(2, 0, 1).unsqueeze(0).float()
+                x = F.interpolate(x, size=(target_h, target_w), mode="bicubic", align_corners=False)
+                t = x.clamp(0, 255).squeeze(0).permute(1, 2, 0).round().to(torch.uint8)
+            f.write(t.contiguous().numpy().tobytes())
+            n += 1
+    container.close()
+    return n
+
+
+if __name__ == "__main__":
+    src, dst = sys.argv[1], sys.argv[2]
+    n = decode_and_resize_to_file(src, dst)
+    print(f"saved {n} frames")

--- a/submissions/roi_gop300_c34/inflate.sh
+++ b/submissions/roi_gop300_c34/inflate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+mkdir -p "$OUTPUT_DIR"
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  BASE="${line%.*}"
+  SRC="${DATA_DIR}/${BASE}.mkv"
+  DST="${OUTPUT_DIR}/${BASE}.raw"
+  [ ! -f "$SRC" ] && echo "ERROR: ${SRC} not found" >&2 && exit 1
+  cd "$ROOT"
+  python -m submissions.roi_gop300_c34.inflate "$SRC" "$DST"
+done < "$FILE_LIST"

--- a/submissions/roi_gop300_c34/roi_preprocess.py
+++ b/submissions/roi_gop300_c34/roi_preprocess.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+import av
+import torch
+import torch.nn.functional as F
+from PIL import Image, ImageDraw, ImageFilter
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+  sys.path.insert(0, str(ROOT))
+
+from frame_utils import yuv420_to_rgb
+
+
+def collapse_chroma(x: torch.Tensor, mode: str) -> torch.Tensor:
+  if mode == "normal":
+    return x
+  if mode == "soft":
+    k = 1
+  elif mode == "medium":
+    k = 2
+  elif mode == "strong":
+    k = 4
+  else:
+    raise ValueError(f"unknown chroma mode: {mode}")
+  uv = x[:, 1:3]
+  uv = F.avg_pool2d(uv, kernel_size=k * 2 + 1, stride=1, padding=k)
+  x[:, 1:3] = uv
+  return x
+
+
+def apply_luma_denoise(x: torch.Tensor, strength: float) -> torch.Tensor:
+  if strength <= 0:
+    return x
+  kernel_size = 3 if strength <= 2.0 else 5
+  sigma = max(0.1, strength * 0.35)
+  coords = torch.arange(kernel_size, device=x.device) - kernel_size // 2
+  g = torch.exp(-(coords ** 2) / (2 * sigma * sigma))
+  kernel_1d = (g / g.sum()).float()
+  kernel_2d = torch.outer(kernel_1d, kernel_1d).view(1, 1, kernel_size, kernel_size)
+  y = x[:, 0:1]
+  y_blur = F.conv2d(y, kernel_2d, padding=kernel_size // 2)
+  blend = min(0.9, strength / 3.0)
+  x[:, 0:1] = (1 - blend) * y + blend * y_blur
+  return x
+
+
+def rgb_to_yuv(rgb: torch.Tensor) -> torch.Tensor:
+  r = rgb[:, 0:1]
+  g = rgb[:, 1:2]
+  b = rgb[:, 2:3]
+  y = 0.299 * r + 0.587 * g + 0.114 * b
+  u = (b - y) / 1.772 + 128.0
+  v = (r - y) / 1.402 + 128.0
+  return torch.cat([y, u, v], dim=1)
+
+
+def yuv_to_rgb(yuv: torch.Tensor) -> torch.Tensor:
+  y = yuv[:, 0:1]
+  u = yuv[:, 1:2] - 128.0
+  v = yuv[:, 2:3] - 128.0
+  r = y + 1.402 * v
+  g = y - 0.344136 * u - 0.714136 * v
+  b = y + 1.772 * u
+  return torch.cat([r, g, b], dim=1)
+
+
+def segment_polygon(frame_idx: int, width: int, height: int) -> list[tuple[float, float]]:
+  segments = [
+    (0, 299, [(0.14, 0.52), (0.82, 0.48), (0.98, 1.00), (0.05, 1.00)]),
+    (300, 599, [(0.10, 0.50), (0.76, 0.47), (0.92, 1.00), (0.00, 1.00)]),
+    (600, 899, [(0.18, 0.50), (0.84, 0.47), (0.98, 1.00), (0.06, 1.00)]),
+    (900, 1199, [(0.22, 0.52), (0.90, 0.49), (1.00, 1.00), (0.10, 1.00)]),
+  ]
+  for start, end, poly in segments:
+    if start <= frame_idx <= end:
+      return [(x * width, y * height) for x, y in poly]
+  return [(0.15 * width, 0.52 * height), (0.85 * width, 0.48 * height), (width, height), (0, height)]
+
+
+def build_mask(frame_idx: int, width: int, height: int, feather_radius: int) -> torch.Tensor:
+  img = Image.new("L", (width, height), 0)
+  draw = ImageDraw.Draw(img)
+  draw.polygon(segment_polygon(frame_idx, width, height), fill=255)
+  if feather_radius > 0:
+    img = img.filter(ImageFilter.GaussianBlur(radius=feather_radius))
+  mask = torch.frombuffer(memoryview(img.tobytes()), dtype=torch.uint8).clone().view(height, width).float() / 255.0
+  return mask.unsqueeze(0).unsqueeze(0)
+
+
+def process_frame(
+  frame_rgb: torch.Tensor,
+  frame_idx: int,
+  outside_luma_denoise: float,
+  outside_chroma_mode: str,
+  feather_radius: int,
+  outside_blend: float,
+) -> torch.Tensor:
+  chw = frame_rgb.permute(2, 0, 1).float().unsqueeze(0)
+  mask = build_mask(frame_idx, chw.shape[-1], chw.shape[-2], feather_radius).to(chw.device)
+  yuv = rgb_to_yuv(chw)
+  processed = yuv.clone()
+  processed = apply_luma_denoise(processed, outside_luma_denoise)
+  processed = collapse_chroma(processed, outside_chroma_mode)
+  processed_rgb = yuv_to_rgb(processed)
+  outside_alpha = (1.0 - mask) * outside_blend
+  mixed = chw * (1.0 - outside_alpha) + processed_rgb * outside_alpha
+  return mixed.clamp(0, 255).round().to(torch.uint8).squeeze(0).permute(1, 2, 0)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description="Hand-authored ROI preprocessor for AV1 encode.")
+  parser.add_argument("--input", type=Path, required=True)
+  parser.add_argument("--output", type=Path, required=True)
+  parser.add_argument("--outside-luma-denoise", type=float, default=0.0)
+  parser.add_argument("--outside-chroma-mode", type=str, default="normal")
+  parser.add_argument("--feather-radius", type=int, default=32)
+  parser.add_argument("--outside-blend", type=float, default=1.0)
+  args = parser.parse_args()
+
+  in_container = av.open(str(args.input))
+  in_stream = in_container.streams.video[0]
+  width = in_stream.width
+  height = in_stream.height
+
+  out_container = av.open(str(args.output), mode="w")
+  out_stream = out_container.add_stream("ffv1", rate=20)
+  out_stream.width = width
+  out_stream.height = height
+  out_stream.pix_fmt = "yuv420p"
+
+  for frame_idx, frame in enumerate(in_container.decode(in_stream)):
+    rgb = yuv420_to_rgb(frame)
+    out_rgb = process_frame(
+      rgb,
+      frame_idx=frame_idx,
+      outside_luma_denoise=args.outside_luma_denoise,
+      outside_chroma_mode=args.outside_chroma_mode,
+      feather_radius=args.feather_radius,
+      outside_blend=args.outside_blend,
+    )
+    video_frame = av.VideoFrame.from_ndarray(out_rgb.cpu().numpy(), format="rgb24")
+    for packet in out_stream.encode(video_frame):
+      out_container.mux(packet)
+
+  for packet in out_stream.encode():
+    out_container.mux(packet)
+
+  out_container.close()
+  in_container.close()
+
+
+if __name__ == "__main__":
+  main()
+


### PR DESCRIPTION
# submission name:
roi_gop300_c34

# upload zipped archive.zip
https://github.com/mil1200/comma_video_compression_challenge/releases/download/roi_gop300_c34/archive.zip

# report.txt
=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.07951669
  Average SegNet Distortion: 0.00566362
  Submission file size: 821,983 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.02189299
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 2.01

# does your submission require gpu for evaluation (inflation)?
no

# did you include the compression script? and want it to be merged?
yes

# additional comments
Builds on the ROI spatial preprocessing approach but with tuned encoding parameters based on systematic grid search over CRF, GOP length, film-grain levels, scale factors and unsharp amounts. Key changes from previous best:

- CRF 34 instead of 33: slightly more aggressive quantization saves enough rate to offset the small distortion increase
- GOP 300 instead of 180: longer prediction chains reduce bitrate without hurting temporal consistency for this driving footage
- enable-qm with qm-min=0: quantization matrices that spend fewer bits on high frequencies irrelevant to the downstream models
- No decoder-side sharpening: tested unsharp amounts 0.0 through 1.2 and found that plain bicubic upscale performs best with ROI preprocessing, likely because the ROI already preserves edge detail where it matters

The ROI preprocessing selectively denoises regions outside the driving corridor (sky, parked cars, vegetation) in YUV space, saving bits for the road surface and class boundaries that dominate the scoring metric. Luma denoise at strength 2.5 with medium chroma collapse, feathered at 48px.

Tested on local eval with AVVideoDataset (no DALI).