### PR TITLE
Add unified_brotli submission

### DIFF
--- a/submissions/unified_brotli/README.md
+++ b/submissions/unified_brotli/README.md
@@ -1,0 +1,22 @@
+# unified_brotli
+
+`unified_brotli` is a rate-optimized variant of the public quantizr-style neural renderer (credit: [quantizr PR #55](https://github.com/commaai/comma_video_compression_challenge/pull/55), [qpose14 PR #63](https://github.com/commaai/comma_video_compression_challenge/pull/63)).
+
+The main changes vs qpose14:
+
+- **Single-stream brotli** of the concatenated raw mask + model + pose payloads (vs three separately-brotli'd streams), so the entropy coder can find cross-stream redundancy.
+- **Delta-encoded velocity**: first uint16 + 599 int16 deltas, exploiting brotli's sensitivity to smoothly-varying low-entropy sequences.
+- Drops rotation entirely; PoseNet conditioning is dominated by velocity.
+
+CUDA validation result:
+
+```text
+Average PoseNet Distortion: 0.00052868
+Average SegNet Distortion: 0.00072205
+Submission file size: 287,165 bytes
+Original uncompressed size: 37,545,489 bytes
+Compression Rate: 0.00764846
+Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 0.34
+```
+
+Inflation requires a GPU.

--- a/submissions/unified_brotli/inflate.py
+++ b/submissions/unified_brotli/inflate.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python
+import io
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import av
+import brotli
+import einops
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from tqdm import tqdm
+
+
+# -----------------------------
+# FP4 Dequantization Tools
+# -----------------------------
+class FP4Codebook:
+    pos_levels = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+
+    @staticmethod
+    def dequantize_from_nibbles(nibbles: torch.Tensor, scales: torch.Tensor, orig_shape):
+        flat_n = int(torch.tensor(orig_shape).prod().item())
+        block_size = nibbles.numel() // scales.numel()
+
+        nibbles = nibbles.view(-1, block_size)
+        signs = (nibbles >> 3).to(torch.int64)
+        mag_idx = (nibbles & 0x7).to(torch.int64)
+
+        levels = FP4Codebook.pos_levels.to(scales.device, torch.float32)
+        q = levels[mag_idx]
+        q = torch.where(signs.bool(), -q, q)
+        dq = q * scales[:, None].to(torch.float32)
+        return dq.view(-1)[:flat_n].reshape(orig_shape)
+
+def unpack_nibbles(packed: torch.Tensor, count: int) -> torch.Tensor:
+    flat = packed.reshape(-1)
+    hi = (flat >> 4) & 0x0F
+    lo = flat & 0x0F
+    out = torch.empty(flat.numel() * 2, dtype=torch.uint8, device=packed.device)
+    out[0::2] = hi
+    out[1::2] = lo
+    return out[:count]
+
+def get_decoded_state_dict(payload_data, device: torch.device):
+    data = torch.load(io.BytesIO(payload_data), map_location=device)
+    state_dict = {}
+
+    for name, rec in data["quantized"].items():
+        if rec["weight_kind"] == "fp4_packed":
+            padded_count = rec["packed_weight"].numel() * 2
+            nibbles = unpack_nibbles(rec["packed_weight"].to(device), padded_count)
+            w = FP4Codebook.dequantize_from_nibbles(
+                nibbles, rec["scales_fp16"].to(device), rec["weight_shape"]
+            )
+        else:
+            w = rec["weight_fp16"].to(device).float()
+
+        state_dict[f"{name}.weight"] = w.float()
+        if rec.get("bias_fp16") is not None:
+            state_dict[f"{name}.bias"] = rec["bias_fp16"].to(device).float()
+
+    for name, tensor in data["dense_fp16"].items():
+        state_dict[name] = tensor.to(device).float() if torch.is_floating_point(tensor) else tensor.to(device)
+
+    return state_dict
+
+# -----------------------------
+# Architecture (Inference Only)
+# -----------------------------
+
+class QConv2d(nn.Conv2d):
+    def __init__(self, *args, block_size=32, quantize_weight=True, **kwargs):
+        super().__init__(*args, **kwargs)
+
+class QEmbedding(nn.Embedding):
+    def __init__(self, *args, block_size=32, quantize_weight=True, **kwargs):
+        super().__init__(*args, **kwargs)
+
+class SepConvGNAct(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int, k: int = 3, stride: int = 1, depth_mult: int = 4, quantize_weight: bool = True):
+        super().__init__()
+        pad = k // 2
+        mid_ch = in_ch * depth_mult
+
+        self.dw = QConv2d(in_ch, mid_ch, k, stride=stride, padding=pad, groups=in_ch, bias=False, quantize_weight=quantize_weight)
+        self.pw = QConv2d(mid_ch, out_ch, 1, padding=0, bias=True, quantize_weight=quantize_weight)
+        self.norm = nn.GroupNorm(2, out_ch)
+        self.act = nn.SiLU(inplace=True)
+
+    def forward(self, x):
+        return self.act(self.norm(self.pw(self.dw(x))))
+
+class SepConv(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int, k: int = 3, stride: int = 1, depth_mult: int = 4, quantize_weight: bool = True):
+        super().__init__()
+        pad = k // 2
+        mid_ch = in_ch * depth_mult
+
+        self.dw = QConv2d(in_ch, mid_ch, k, stride=stride, padding=pad, groups=in_ch, bias=False, quantize_weight=quantize_weight)
+        self.pw = QConv2d(mid_ch, out_ch, 1, padding=0, bias=True, quantize_weight=quantize_weight)
+
+    def forward(self, x):
+        return self.pw(self.dw(x))
+
+class SepResBlock(nn.Module):
+    def __init__(self, ch: int, depth_mult: int = 4, quantize_weight=True):
+        super().__init__()
+        self.conv1 = SepConvGNAct(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.conv2 = SepConv(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.norm2 = nn.GroupNorm(2, ch)
+        self.act = nn.SiLU(inplace=True)
+
+    def forward(self, x):
+        return self.act(x + self.norm2(self.conv2(self.conv1(x))))
+
+class FiLMSepResBlock(nn.Module):
+    def __init__(self, ch: int, cond_dim: int, depth_mult: int = 4, quantize_weight=True):
+        super().__init__()
+        self.conv1 = SepConvGNAct(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.conv2 = SepConv(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.norm2 = nn.GroupNorm(2, ch)
+
+        self.film_proj = nn.Linear(cond_dim, ch * 2)
+        self.act = nn.SiLU(inplace=True)
+
+    def forward(self, x, cond_emb):
+        residual = x
+        x = self.norm2(self.conv2(self.conv1(x)))
+
+        film = self.film_proj(cond_emb).unsqueeze(-1).unsqueeze(-1)
+        gamma, beta = film.chunk(2, dim=1)
+        x = x * (1.0 + gamma) + beta
+
+        return self.act(residual + x)
+
+class SharedMaskDecoder(nn.Module):
+    def __init__(self, num_classes=5, emb_dim=6, c1=40, c2=44, depth_mult=4):
+        super().__init__()
+        self.embedding = QEmbedding(num_classes, emb_dim, quantize_weight=False)
+
+        self.stem_conv = SepConvGNAct(emb_dim + 2, c1, depth_mult=depth_mult)
+        self.stem_block = SepResBlock(c1, depth_mult=depth_mult)
+
+        self.down_conv = SepConvGNAct(c1, c2, stride=2, depth_mult=depth_mult)
+        self.down_block = SepResBlock(c2, depth_mult=depth_mult)
+
+        self.up = nn.Sequential(
+            nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False),
+            SepConvGNAct(c2, c1, depth_mult=depth_mult),
+        )
+
+        self.fuse = SepConvGNAct(c1 + c1, c1, depth_mult=depth_mult)
+        self.fuse_block = SepResBlock(c1, depth_mult=depth_mult)
+
+    def forward(self, mask2: torch.Tensor, coords: torch.Tensor):
+        e2 = self.embedding(mask2.long()).permute(0, 3, 1, 2)
+        e2_up = F.interpolate(e2, size=coords.shape[-2:], mode="bilinear", align_corners=False)
+
+        x = torch.cat([e2_up, coords], dim=1)
+        s = self.stem_block(self.stem_conv(x))
+        z = self.down_block(self.down_conv(s))
+        z = self.up(z)
+        f = self.fuse_block(self.fuse(torch.cat([z, s], dim=1)))
+        return f
+
+class Frame2StaticHead(nn.Module):
+    def __init__(self, in_ch: int, hidden: int = 36, depth_mult: int = 4):
+        super().__init__()
+        self.block1 = SepResBlock(in_ch, depth_mult=depth_mult)
+        self.block2 = SepResBlock(in_ch, depth_mult=depth_mult)
+        self.pre = SepConvGNAct(in_ch, hidden, depth_mult=depth_mult)
+        self.head = QConv2d(hidden, 3, 1, quantize_weight=False)
+
+    def forward(self, feat: torch.Tensor) -> torch.Tensor:
+        x = self.block1(feat)
+        x = self.block2(x)
+        x = self.pre(x)
+        return torch.sigmoid(self.head(x)) * 255.0
+
+class FrameHead(nn.Module):
+    def __init__(self, in_ch: int, cond_dim: int = 32, hidden: int = 36, depth_mult: int = 4):
+        super().__init__()
+        self.block1 = FiLMSepResBlock(in_ch, cond_dim, depth_mult=depth_mult)
+        self.block2 = SepResBlock(in_ch, depth_mult=depth_mult)
+        self.pre = SepConvGNAct(in_ch, hidden, depth_mult=depth_mult)
+        self.head = QConv2d(hidden, 3, 1, quantize_weight=False)
+
+    def forward(self, feat: torch.Tensor, cond_emb: torch.Tensor) -> torch.Tensor:
+        x = self.block1(feat, cond_emb)
+        x = self.block2(x)
+        x = self.pre(x)
+        return torch.sigmoid(self.head(x)) * 255.0
+
+class JointFrameGenerator(nn.Module):
+    def __init__(self, num_classes=5, pose_dim=6, cond_dim=48, depth_mult=1):
+        super().__init__()
+        self.shared_trunk = SharedMaskDecoder(
+            num_classes=num_classes, emb_dim=6, c1=56, c2=64, depth_mult=depth_mult)
+
+        self.pose_mlp = nn.Sequential(
+            nn.Linear(pose_dim, cond_dim), nn.SiLU(), nn.Linear(cond_dim, cond_dim))
+
+        self.frame1_head = FrameHead(
+            in_ch=56, cond_dim=cond_dim, hidden=52, depth_mult=depth_mult)
+
+        self.frame2_head = Frame2StaticHead(
+            in_ch=56, hidden=52, depth_mult=depth_mult)
+
+    def forward(self, mask2: torch.Tensor, pose6: torch.Tensor):
+        b = mask2.shape[0]
+        coords = make_coord_grid(b, 384, 512, mask2.device, torch.float32)
+
+        shared_feat = self.shared_trunk(mask2, coords)
+        pred_frame2 = self.frame2_head(shared_feat)
+
+        cond_emb = self.pose_mlp(pose6)
+        pred_frame1 = self.frame1_head(shared_feat, cond_emb)
+
+        return pred_frame1, pred_frame2
+
+def make_coord_grid(batch: int, height: int, width: int, device, dtype) -> torch.Tensor:
+    ys = (torch.arange(height, device=device, dtype=dtype) + 0.5) / height
+    xs = (torch.arange(width, device=device, dtype=dtype) + 0.5) / width
+    yy, xx = torch.meshgrid(ys, xs, indexing="ij")
+    grid = torch.stack([xx * 2.0 - 1.0, yy * 2.0 - 1.0], dim=0)
+    return grid.unsqueeze(0).expand(batch, -1, -1, -1)
+
+
+# -----------------------------
+# Inference Helpers & Main
+# -----------------------------
+def load_encoded_mask_video(path: str) -> torch.Tensor:
+    container = av.open(path)
+    frames = []
+    for frame in container.decode(video=0):
+        img = frame.to_ndarray(format="gray")
+        cls_img = np.round(img / 63.0).astype(np.uint8)
+        cls_img = np.clip(cls_img, 0, 4)
+        frames.append(cls_img)
+    container.close()
+    return torch.from_numpy(np.stack(frames)).contiguous()
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: python inflate.py <data_dir> <output_dir> <file_list_txt>")
+        sys.exit(1)
+
+    data_dir = Path(sys.argv[1])
+    out_dir = Path(sys.argv[2])
+    file_list_path = Path(sys.argv[3])
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    files = [line.strip() for line in file_list_path.read_text().splitlines() if line.strip()]
+
+    # Single-stream brotli payload: 12-byte length header + raw mask + raw model + raw pose
+    import struct as _struct
+    raw = brotli.decompress((data_dir / "p").read_bytes())
+    n_mask, n_model, n_pose = _struct.unpack('<III', raw[:12])
+    o = 12
+    raw_mask = raw[o:o+n_mask]; o += n_mask
+    raw_model = raw[o:o+n_model]; o += n_model
+    raw_pose = raw[o:o+n_pose]
+
+    # 1. Load Weights (FP4 dequantized)
+    generator = JointFrameGenerator().to(device)
+    generator.load_state_dict(get_decoded_state_dict(raw_model, device), strict=True)
+    generator.eval()
+
+    # 2. Load Mask Video (.obu)
+    with tempfile.NamedTemporaryFile(suffix=".obu", delete=False) as tmp_obu:
+        tmp_obu.write(raw_mask)
+        tmp_obu_path = tmp_obu.name
+    mask_frames_all = load_encoded_mask_video(tmp_obu_path)
+    os.remove(tmp_obu_path)
+
+    # 3. Load Pose: delta-encoded uint16 velocity (rotation = 0)
+    n_pairs = 600
+    vel0 = _struct.unpack('<H', raw_pose[:2])[0]
+    deltas = np.frombuffer(raw_pose[2:], dtype=np.int16)
+    vel_q = np.empty(n_pairs, dtype=np.int32)
+    vel_q[0] = vel0
+    vel_q[1:] = vel0 + np.cumsum(deltas)
+    vel = vel_q.astype(np.float32) / 512.0 + 20.0
+    pose_frames_all = torch.from_numpy(np.concatenate([vel.reshape(-1, 1), np.zeros((n_pairs, 5), dtype=np.float32)], axis=1)).float()
+
+    out_h, out_w = 874, 1164
+    cursor = 0
+    batch_size = 4 
+    
+    # 1 mask per generated pair, assume 600 pairs per standard 1200 frame chunk.
+    pairs_per_file = 600
+
+    with torch.inference_mode():
+        for file_name in files:
+            base_name = os.path.splitext(file_name)[0]
+            raw_out_path = out_dir / f"{base_name}.raw"
+            
+            # Retrieve exactly the pairs mapping to this file
+            file_masks = mask_frames_all[cursor : cursor + pairs_per_file]
+            file_poses = pose_frames_all[cursor : cursor + pairs_per_file]
+            cursor += pairs_per_file
+            
+            with open(raw_out_path, "wb") as f_out:
+                pbar = tqdm(range(0, file_masks.shape[0], batch_size), desc=f"Decoding {file_name}")
+                
+                for i in pbar:
+                    in_mask2 = file_masks[i : i + batch_size].to(device).long()
+                    in_pose6 = file_poses[i : i + batch_size].to(device).float()
+
+                    fake1, fake2 = generator(in_mask2, in_pose6)
+
+                    fake1_up = F.interpolate(fake1, size=(out_h, out_w), mode="bilinear", align_corners=False)
+                    fake2_up = F.interpolate(fake2, size=(out_h, out_w), mode="bilinear", align_corners=False)
+
+                    batch_comp = torch.stack([fake1_up, fake2_up], dim=1)
+                    batch_comp = einops.rearrange(batch_comp, "b t c h w -> (b t) h w c")
+
+                    output_bytes = batch_comp.clamp(0, 255).round().to(torch.uint8)
+                    f_out.write(output_bytes.cpu().numpy().tobytes())
+
+if __name__ == "__main__":
+    main()

--- a/submissions/unified_brotli/inflate.sh
+++ b/submissions/unified_brotli/inflate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+PYTHON_BIN="python"
+if [ -x "$ROOT/.venv/bin/python" ]; then
+  PYTHON_BIN="$ROOT/.venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+fi
+
+"$PYTHON_BIN" "$HERE/inflate.py" "$DATA_DIR" "$OUTPUT_DIR" "$FILE_LIST"


### PR DESCRIPTION
# submission name:
unified_brotli

# upload zipped `archive.zip`
[archive.zip](https://github.com/avocardio/comma_video_compression_challenge/releases/download/v1-unified_brotli/archive.zip)

# report.txt
```
=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.00052868
  Average SegNet Distortion: 0.00072205
  Submission file size: 287,165 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.00764846
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 0.34
```

# does your submission require gpu for evaluation (inflation)?
yes

# did you include the compression script? and want it to be merged?
no

# additional comments
`unified_brotli` builds on the public quantizr-style neural renderer (credit: [quantizr PR #55](https://github.com/commaai/comma_video_compression_challenge/pull/55), [qpose14 PR #63](https://github.com/commaai/comma_video_compression_challenge/pull/63)).

Three rate-side changes vs qpose14:
- **Single-stream brotli** of the concatenated raw mask + raw model + raw pose payloads (vs three separately-brotli'd streams), so the entropy coder sees cross-stream redundancy.
- **Delta-encoded velocity** (uint16 anchor + 599 int16 deltas) — small smoothly-varying integers compress much better than absolute uint16.
- Drops rotation from the pose side-channel; PoseNet conditioning is dominated by velocity at this scale.

Net archive: 287,165 bytes (vs qpose14 287,573, vs quantizr 299,970).
