### PR TITLE
qzs3_range_joint_r258 (0.26)

### DIFF
--- a/submissions/qzs3_range_joint_r258/inflate.py
+++ b/submissions/qzs3_range_joint_r258/inflate.py
@@ -1,0 +1,1939 @@
+#!/usr/bin/env python
+import io
+import json
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import av
+import brotli
+import einops
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from tqdm import tqdm
+
+COMPOSITE_ACTION_MAGIC = b"RMC1"
+SIDE_ACTION_MAGIC = b"RSA1"
+SIDE_ACTION_BROTLI_MAGIC = b"RSB1"
+ROUTER_ACTION_COUNT = 600
+ROUTER_ACTION_BYTES = 225
+ROUTER_ACTION_BITS = 3
+
+
+# -----------------------------
+# FP4 Dequantization Tools
+# -----------------------------
+class FP4Codebook:
+    pos_levels = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+
+    @staticmethod
+    def dequantize_from_nibbles(nibbles: torch.Tensor, scales: torch.Tensor, orig_shape):
+        flat_n = int(torch.tensor(orig_shape).prod().item())
+        block_size = nibbles.numel() // scales.numel()
+
+        nibbles = nibbles.view(-1, block_size)
+        signs = (nibbles >> 3).to(torch.int64)
+        mag_idx = (nibbles & 0x7).to(torch.int64)
+
+        levels = FP4Codebook.pos_levels.to(scales.device, torch.float32)
+        q = levels[mag_idx]
+        q = torch.where(signs.bool(), -q, q)
+        dq = q * scales[:, None].to(torch.float32)
+        return dq.view(-1)[:flat_n].reshape(orig_shape)
+
+def unpack_nibbles(packed: torch.Tensor, count: int) -> torch.Tensor:
+    flat = packed.reshape(-1)
+    hi = (flat >> 4) & 0x0F
+    lo = flat & 0x0F
+    out = torch.empty(flat.numel() * 2, dtype=torch.uint8, device=packed.device)
+    out[0::2] = hi
+    out[1::2] = lo
+    return out[:count]
+
+
+def _unsplit_bytes_to_tensor(payload_data: bytes, pos: int, nbytes: int, dtype, shape, device):
+    half = (nbytes + 1) // 2
+    a = np.frombuffer(payload_data[pos:pos+nbytes], dtype=np.uint8)
+    out = np.empty(nbytes, dtype=np.uint8)
+    out[0::2] = a[:half]
+    out[1::2] = a[half:]
+    t = torch.frombuffer(bytearray(out.tobytes()), dtype=dtype).clone().reshape(shape).to(device)
+    return t, pos + nbytes
+
+def _unhilo_packed(payload_data: bytes, pos: int, packed_len: int, device):
+    half = packed_len // 2
+    hp = np.frombuffer(payload_data[pos:pos+half], dtype=np.uint8); pos += half
+    lp = np.frombuffer(payload_data[pos:pos+half], dtype=np.uint8); pos += half
+    hi = np.empty(half * 2, dtype=np.uint8); lo = np.empty(half * 2, dtype=np.uint8)
+    hi[0::2] = (hp >> 4) & 15; hi[1::2] = hp & 15
+    lo[0::2] = (lp >> 4) & 15; lo[1::2] = lp & 15
+    packed = ((hi[:packed_len] << 4) | lo[:packed_len]).astype(np.uint8)
+    return torch.frombuffer(bytearray(packed.tobytes()), dtype=torch.uint8).clone().to(device), pos
+
+def get_decoded_state_dict_custom(payload_data: bytes, device: torch.device):
+    magic = payload_data[:3]
+    if magic not in (b"QM0", b"QH0"):
+        return None
+    pos = 3
+    hilosplit = magic == b"QH0"
+    state_dict = {}
+    probe = JointFrameGenerator()
+    covered = set()
+    for name, module in probe.named_modules():
+        if not isinstance(module, (QConv2d, QEmbedding)):
+            continue
+        kind = payload_data[pos]
+        pos += 1
+        shape = tuple(module.weight.shape)
+        numel = int(module.weight.numel())
+        if kind == 1:
+            block_size = 32
+            blocks = (numel + block_size - 1) // block_size
+            packed_len = (blocks * block_size + 1) // 2
+            if hilosplit:
+                packed, pos = _unhilo_packed(payload_data, pos, packed_len, device)
+                scales, pos = _unsplit_bytes_to_tensor(payload_data, pos, blocks * 2, torch.float16, (blocks,), device)
+            else:
+                packed = torch.frombuffer(bytearray(payload_data[pos:pos + packed_len]), dtype=torch.uint8).clone().to(device)
+                pos += packed_len
+                scales = torch.frombuffer(bytearray(payload_data[pos:pos + blocks * 2]), dtype=torch.float16).clone().to(device)
+                pos += blocks * 2
+            nibbles = unpack_nibbles(packed, packed.numel() * 2)
+            w = FP4Codebook.dequantize_from_nibbles(nibbles, scales, shape)
+        elif kind == 0:
+            nbytes = numel * 2
+            if hilosplit:
+                w, pos = _unsplit_bytes_to_tensor(payload_data, pos, nbytes, torch.float16, shape, device)
+                w = w.float()
+            else:
+                w = torch.frombuffer(bytearray(payload_data[pos:pos + nbytes]), dtype=torch.float16).clone().reshape(shape).to(device).float()
+                pos += nbytes
+        else:
+            raise ValueError(f"bad custom model q kind {kind} for {name}")
+        state_dict[f"{name}.weight"] = w.float()
+        covered.add(f"{name}.weight")
+        if getattr(module, "bias", None) is not None:
+            n = int(module.bias.numel())
+            if hilosplit:
+                b, pos = _unsplit_bytes_to_tensor(payload_data, pos, n * 2, torch.float16, tuple(module.bias.shape), device)
+                b = b.float()
+            else:
+                b = torch.frombuffer(bytearray(payload_data[pos:pos + n * 2]), dtype=torch.float16).clone().reshape(tuple(module.bias.shape)).to(device).float()
+                pos += n * 2
+            state_dict[f"{name}.bias"] = b
+            covered.add(f"{name}.bias")
+    for key, tensor in probe.state_dict().items():
+        if key in covered:
+            continue
+        kind = payload_data[pos]
+        pos += 1
+        shape = tuple(tensor.shape)
+        numel = int(tensor.numel())
+        if kind == 2:
+            q = torch.frombuffer(bytearray(payload_data[pos:pos + numel]), dtype=torch.int8).clone().reshape(shape).to(device)
+            pos += numel
+            rows = shape[0] if len(shape) >= 2 else 1
+            if hilosplit:
+                scales, pos = _unsplit_bytes_to_tensor(payload_data, pos, rows * 2, torch.float16, (rows,), device)
+                scales = scales.float()
+            else:
+                scales = torch.frombuffer(bytearray(payload_data[pos:pos + rows * 2]), dtype=torch.float16).clone().to(device).float()
+                pos += rows * 2
+            state_dict[key] = (q.float() * scales[:, None]).reshape(shape)
+        elif kind == 0:
+            nbytes = numel * 2
+            if hilosplit:
+                t, pos = _unsplit_bytes_to_tensor(payload_data, pos, nbytes, torch.float16, shape, device)
+                state_dict[key] = t.float()
+            else:
+                state_dict[key] = torch.frombuffer(bytearray(payload_data[pos:pos + nbytes]), dtype=torch.float16).clone().reshape(shape).to(device).float()
+                pos += nbytes
+        else:
+            raise ValueError(f"bad custom model dense kind {kind} for {key}")
+    return state_dict
+
+def get_decoded_state_dict(payload_data, device: torch.device):
+    custom = get_decoded_state_dict_custom(payload_data, device)
+    if custom is not None:
+        return custom
+    data = torch.load(io.BytesIO(payload_data), map_location=device)
+    state_dict = {}
+
+    for name, rec in data["quantized"].items():
+        if rec["weight_kind"] == "fp4_packed":
+            padded_count = rec["packed_weight"].numel() * 2
+            nibbles = unpack_nibbles(rec["packed_weight"].to(device), padded_count)
+            w = FP4Codebook.dequantize_from_nibbles(
+                nibbles, rec["scales_fp16"].to(device), rec["weight_shape"]
+            )
+        else:
+            w = rec["weight_fp16"].to(device).float()
+
+        state_dict[f"{name}.weight"] = w.float()
+        if rec.get("bias_fp16") is not None:
+            state_dict[f"{name}.bias"] = rec["bias_fp16"].to(device).float()
+
+    for name, tensor in data["dense_fp16"].items():
+        state_dict[name] = tensor.to(device).float() if torch.is_floating_point(tensor) else tensor.to(device)
+
+    for name, rec in data.get("dense_i8", {}).items():
+        q = rec["q_int8"].to(device)
+        scales = rec["scales_fp16"].to(device).float()
+        state_dict[name] = (q.float() * scales[:, None]).reshape(rec.get("shape", q.shape))
+
+    return state_dict
+
+# -----------------------------
+# Architecture (Inference Only)
+# -----------------------------
+
+class QConv2d(nn.Conv2d):
+    def __init__(self, *args, block_size=32, quantize_weight=True, **kwargs):
+        super().__init__(*args, **kwargs)
+
+class QEmbedding(nn.Embedding):
+    def __init__(self, *args, block_size=32, quantize_weight=True, **kwargs):
+        super().__init__(*args, **kwargs)
+
+class SepConvGNAct(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int, k: int = 3, stride: int = 1, depth_mult: int = 4, quantize_weight: bool = True):
+        super().__init__()
+        pad = k // 2
+        mid_ch = in_ch * depth_mult
+
+        self.dw = QConv2d(in_ch, mid_ch, k, stride=stride, padding=pad, groups=in_ch, bias=False, quantize_weight=quantize_weight)
+        self.pw = QConv2d(mid_ch, out_ch, 1, padding=0, bias=True, quantize_weight=quantize_weight)
+        self.norm = nn.GroupNorm(2, out_ch)
+        self.act = nn.SiLU(inplace=True)
+
+    def forward(self, x):
+        return self.act(self.norm(self.pw(self.dw(x))))
+
+class SepConv(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int, k: int = 3, stride: int = 1, depth_mult: int = 4, quantize_weight: bool = True):
+        super().__init__()
+        pad = k // 2
+        mid_ch = in_ch * depth_mult
+
+        self.dw = QConv2d(in_ch, mid_ch, k, stride=stride, padding=pad, groups=in_ch, bias=False, quantize_weight=quantize_weight)
+        self.pw = QConv2d(mid_ch, out_ch, 1, padding=0, bias=True, quantize_weight=quantize_weight)
+
+    def forward(self, x):
+        return self.pw(self.dw(x))
+
+class SepResBlock(nn.Module):
+    def __init__(self, ch: int, depth_mult: int = 4, quantize_weight=True):
+        super().__init__()
+        self.conv1 = SepConvGNAct(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.conv2 = SepConv(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.norm2 = nn.GroupNorm(2, ch)
+        self.act = nn.SiLU(inplace=True)
+
+    def forward(self, x):
+        return self.act(x + self.norm2(self.conv2(self.conv1(x))))
+
+class FiLMSepResBlock(nn.Module):
+    def __init__(self, ch: int, cond_dim: int, depth_mult: int = 4, quantize_weight=True):
+        super().__init__()
+        self.conv1 = SepConvGNAct(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.conv2 = SepConv(ch, ch, 3, 1, depth_mult=depth_mult, quantize_weight=quantize_weight)
+        self.norm2 = nn.GroupNorm(2, ch)
+
+        self.film_proj = nn.Linear(cond_dim, ch * 2)
+        self.act = nn.SiLU(inplace=True)
+
+    def forward(self, x, cond_emb):
+        residual = x
+        x = self.norm2(self.conv2(self.conv1(x)))
+
+        film = self.film_proj(cond_emb).unsqueeze(-1).unsqueeze(-1)
+        gamma, beta = film.chunk(2, dim=1)
+        x = x * (1.0 + gamma) + beta
+
+        return self.act(residual + x)
+
+class SharedMaskDecoder(nn.Module):
+    def __init__(self, num_classes=5, emb_dim=6, c1=40, c2=44, depth_mult=4):
+        super().__init__()
+        self.embedding = QEmbedding(num_classes, emb_dim, quantize_weight=False)
+
+        self.stem_conv = SepConvGNAct(emb_dim + 2, c1, depth_mult=depth_mult)
+        self.stem_block = SepResBlock(c1, depth_mult=depth_mult)
+
+        self.down_conv = SepConvGNAct(c1, c2, stride=2, depth_mult=depth_mult)
+        self.down_block = SepResBlock(c2, depth_mult=depth_mult)
+
+        self.up = nn.Sequential(
+            nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False),
+            SepConvGNAct(c2, c1, depth_mult=depth_mult),
+        )
+
+        self.fuse = SepConvGNAct(c1 + c1, c1, depth_mult=depth_mult)
+        self.fuse_block = SepResBlock(c1, depth_mult=depth_mult)
+
+    def forward(self, mask2: torch.Tensor, coords: torch.Tensor):
+        e2 = self.embedding(mask2.long()).permute(0, 3, 1, 2)
+        e2_up = F.interpolate(e2, size=coords.shape[-2:], mode="bilinear", align_corners=False)
+
+        x = torch.cat([e2_up, coords], dim=1)
+        s = self.stem_block(self.stem_conv(x))
+        z = self.down_block(self.down_conv(s))
+        z = self.up(z)
+        f = self.fuse_block(self.fuse(torch.cat([z, s], dim=1)))
+        return f
+
+class Frame2StaticHead(nn.Module):
+    def __init__(self, in_ch: int, hidden: int = 36, depth_mult: int = 4):
+        super().__init__()
+        self.block1 = SepResBlock(in_ch, depth_mult=depth_mult)
+        self.block2 = SepResBlock(in_ch, depth_mult=depth_mult)
+        self.pre = SepConvGNAct(in_ch, hidden, depth_mult=depth_mult)
+        self.head = QConv2d(hidden, 3, 1, quantize_weight=False)
+
+    def forward(self, feat: torch.Tensor) -> torch.Tensor:
+        x = self.block1(feat)
+        x = self.block2(x)
+        x = self.pre(x)
+        return torch.sigmoid(self.head(x)) * 255.0
+
+class FrameHead(nn.Module):
+    def __init__(self, in_ch: int, cond_dim: int = 32, hidden: int = 36, depth_mult: int = 4):
+        super().__init__()
+        self.block1 = FiLMSepResBlock(in_ch, cond_dim, depth_mult=depth_mult)
+        self.block2 = SepResBlock(in_ch, depth_mult=depth_mult)
+        self.pre = SepConvGNAct(in_ch, hidden, depth_mult=depth_mult)
+        self.head = QConv2d(hidden, 3, 1, quantize_weight=False)
+
+    def forward(self, feat: torch.Tensor, cond_emb: torch.Tensor) -> torch.Tensor:
+        x = self.block1(feat, cond_emb)
+        x = self.block2(x)
+        x = self.pre(x)
+        return torch.sigmoid(self.head(x)) * 255.0
+
+class JointFrameGenerator(nn.Module):
+    def __init__(self, num_classes=5, pose_dim=6, cond_dim=48, depth_mult=1):
+        super().__init__()
+        self.shared_trunk = SharedMaskDecoder(
+            num_classes=num_classes, emb_dim=6, c1=56, c2=64, depth_mult=depth_mult)
+
+        self.pose_mlp = nn.Sequential(
+            nn.Linear(pose_dim, cond_dim), nn.SiLU(), nn.Linear(cond_dim, cond_dim))
+
+        self.frame1_head = FrameHead(
+            in_ch=56, cond_dim=cond_dim, hidden=52, depth_mult=depth_mult)
+
+        self.frame2_head = Frame2StaticHead(
+            in_ch=56, hidden=52, depth_mult=depth_mult)
+
+    def forward(self, mask2: torch.Tensor, pose6: torch.Tensor):
+        b = mask2.shape[0]
+        coords = make_coord_grid(b, 384, 512, mask2.device, torch.float32)
+
+        shared_feat = self.shared_trunk(mask2, coords)
+        pred_frame2 = self.frame2_head(shared_feat)
+
+        cond_emb = self.pose_mlp(pose6)
+        pred_frame1 = self.frame1_head(shared_feat, cond_emb)
+
+        return pred_frame1, pred_frame2
+
+def make_coord_grid(batch: int, height: int, width: int, device, dtype) -> torch.Tensor:
+    ys = (torch.arange(height, device=device, dtype=dtype) + 0.5) / height
+    xs = (torch.arange(width, device=device, dtype=dtype) + 0.5) / width
+    yy, xx = torch.meshgrid(ys, xs, indexing="ij")
+    grid = torch.stack([xx * 2.0 - 1.0, yy * 2.0 - 1.0], dim=0)
+    return grid.unsqueeze(0).expand(batch, -1, -1, -1)
+
+
+# -----------------------------
+# Inference Helpers & Main
+# -----------------------------
+
+def load_range_mask(mask_payload: bytes) -> torch.Tensor:
+    codec_src = Path(__file__).with_name("range_mask_codec.cpp")
+    if not codec_src.exists():
+        raise RuntimeError(f"missing range-mask decoder source: {codec_src}")
+    if len(mask_payload) < 20:
+        raise RuntimeError("truncated range-mask payload")
+    t_count = int.from_bytes(mask_payload[4:8], "little")
+    mask_h = int.from_bytes(mask_payload[8:12], "little")
+    mask_w = int.from_bytes(mask_payload[12:16], "little")
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        exe = td_path / "range_mask_codec"
+        compiler_candidates = [os.environ.get("CXX", ""), "c++", "g++", "clang++"]
+        last_error = None
+        for compiler in dict.fromkeys(c for c in compiler_candidates if c):
+            compiler_path = shutil.which(compiler)
+            if compiler_path is None:
+                continue
+            try:
+                subprocess.run([compiler_path, "-O3", "-std=c++17", str(codec_src), "-o", str(exe)], check=True)
+                break
+            except subprocess.CalledProcessError as exc:
+                last_error = exc
+        else:
+            raise RuntimeError("failed to compile range-mask decoder with c++/g++/clang++") from last_error
+        packed = td_path / "mask.range"
+        raw = td_path / "mask.raw"
+        packed.write_bytes(mask_payload)
+        subprocess.run([str(exe), "decode", str(packed), str(raw)], check=True)
+        decoded = np.frombuffer(raw.read_bytes(), dtype=np.uint8)
+        if (t_count, mask_h, mask_w) == (600, 512, 384):
+            arr = decoded.reshape(600, 512, 384).transpose(0, 2, 1).copy()
+        elif (t_count, mask_h, mask_w) == (600, 384, 512):
+            arr = decoded.reshape(600, 384, 512).copy()
+        else:
+            raise RuntimeError(f"unexpected range-mask dimensions: {(t_count, mask_h, mask_w)}")
+    return torch.from_numpy(arr).contiguous()
+
+def load_encoded_mask_video(path: str) -> torch.Tensor:
+    container = av.open(path)
+    frames = []
+    for frame in container.decode(video=0):
+        img = frame.to_ndarray(format="gray")
+        cls_img = np.round(img / 63.0).astype(np.uint8)
+        cls_img = np.clip(cls_img, 0, 4)
+        frames.append(cls_img)
+    container.close()
+    return torch.from_numpy(np.stack(frames)).contiguous()
+
+def unpack_pose_q12(raw: bytes) -> np.ndarray:
+    if raw[:4] == b"PQB1":
+        n, d, bits = struct.unpack_from("<HHBxxx", raw, 4)
+        off = 12
+        mn = np.frombuffer(raw, dtype="<f4", count=d, offset=off).astype(np.float32)
+        off += 4 * d
+        scale = np.frombuffer(raw, dtype="<f4", count=d, offset=off).astype(np.float32)
+        off += 4 * d
+        data = np.frombuffer(raw, dtype=np.uint8, offset=off)
+        total = n * d
+        vals = np.empty(total, dtype=np.uint16)
+        bitbuf = 0
+        bitcount = 0
+        byte_i = 0
+        mask = (1 << bits) - 1
+        for i in range(total):
+            while bitcount < bits:
+                bitbuf |= int(data[byte_i]) << bitcount
+                byte_i += 1
+                bitcount += 8
+            vals[i] = bitbuf & mask
+            bitbuf >>= bits
+            bitcount -= bits
+        return mn[None, :] + vals.reshape(n, d).astype(np.float32) * scale[None, :]
+    if raw[:4] != b"PQ12":
+        raise ValueError("bad pose_q magic")
+    n, d = struct.unpack_from("<HH", raw, 4)
+    off = 8
+    mn = np.frombuffer(raw, dtype="<f4", count=d, offset=off).astype(np.float32)
+    off += 4 * d
+    scale = np.frombuffer(raw, dtype="<f4", count=d, offset=off).astype(np.float32)
+    off += 4 * d
+    p = np.frombuffer(raw, dtype=np.uint8, offset=off).reshape(-1, 3).astype(np.uint16)
+    q0 = p[:, 0] | ((p[:, 1] & 0x0F) << 8)
+    q1 = (p[:, 1] >> 4) | (p[:, 2] << 4)
+    q = np.empty(p.shape[0] * 2, dtype=np.uint16)
+    q[0::2] = q0
+    q[1::2] = q1
+    return mn[None, :] + q[: n * d].reshape(n, d).astype(np.float32) * scale[None, :]
+
+def load_pose_frames(path_or_dir) -> torch.Tensor:
+    path = Path(path_or_dir)
+    if path.is_dir():
+        path = path / "pose.npy.br"
+    if path.exists():
+        with open(path, "rb") as f:
+            pose_bytes = brotli.decompress(f.read())
+        return torch.from_numpy(np.load(io.BytesIO(pose_bytes))).float()
+    qpath = path.with_name("pose_q.br")
+    if qpath.exists():
+        return torch.from_numpy(unpack_pose_q12(brotli.decompress(qpath.read_bytes()))).float()
+    raise FileNotFoundError(path)
+
+def load_pose_frames_from_payload(encoded_pose: bytes) -> torch.Tensor:
+    pose_bytes = encoded_pose if encoded_pose[:4] in (b"PQ12", b"PQB1") else brotli.decompress(encoded_pose)
+    if pose_bytes[:4] in (b"PQ12", b"PQB1"):
+        return torch.from_numpy(unpack_pose_q12(pose_bytes)).float()
+    if pose_bytes[:4] == b"P1D1":
+        n = 600
+        pos = 4
+        cnt = pose_bytes[pos]; pos += 1
+        dims = []
+        lens = []
+        for _ in range(cnt):
+            dims.append(int(pose_bytes[pos])); pos += 1
+            lens.append(int.from_bytes(pose_bytes[pos:pos+2], "little")); pos += 2
+        pose_np = np.zeros((n, 6), dtype=np.float32)
+        for d, ln in zip(dims, lens):
+            stream = pose_bytes[pos:pos+ln]; pos += ln
+            vals = np.empty(n, dtype=np.uint32)
+            acc = 0; shift = 0; j = 0
+            for byte in stream:
+                acc |= (int(byte) & 0x7f) << shift
+                if byte & 0x80:
+                    shift += 7
+                else:
+                    vals[j] = acc; j += 1; acc = 0; shift = 0
+                    if j >= n: break
+            delta = ((vals.astype(np.int32) >> 1) ^ -(vals.astype(np.int32) & 1)).astype(np.int32)
+            q = np.cumsum(delta)
+            if int(d) == 0:
+                pose_np[:, 0] = q.astype(np.float32) / 512.0 + 20.0
+            else:
+                q = q.clip(-32768, 32767).astype(np.int16)
+                pose_np[:, int(d)] = q.astype(np.float32) / 2048.0
+        return torch.from_numpy(pose_np).float()
+    return torch.from_numpy(np.load(io.BytesIO(pose_bytes))).float()
+
+def _post_pair_tensor(value, default, device: torch.device):
+    arr = torch.tensor(value if value is not None else default, dtype=torch.float32, device=device)
+    if arr.ndim == 1:
+        arr = arr.view(1, 1, 1, 3).expand(2, 1, 1, 3)
+    elif arr.ndim == 2 and tuple(arr.shape) == (2, 3):
+        arr = arr.view(2, 1, 1, 3)
+    else:
+        raise ValueError(f"Bad postprocess tensor shape: {tuple(arr.shape)}")
+    return arr
+
+def _post_stage_from_defs(defs, choices_data, device: torch.device):
+    gains = torch.stack([_post_pair_tensor(gain, [1.0, 1.0, 1.0], device) for gain, _ in defs], dim=0)
+    biases = torch.stack([_post_pair_tensor(bias, [0.0, 0.0, 0.0], device) for _, bias in defs], dim=0)
+    choices = torch.tensor([int(x) for x in choices_data], dtype=torch.long, device=device)
+    return gains, biases, choices
+
+def _B(r=0, g=0, b=0):
+    return (float(r), float(g), float(b))
+
+def _PB(f0=(0, 0, 0), f1=(0, 0, 0)):
+    return (_B(*f0), _B(*f1))
+
+def _post_defs(stage_id: int):
+    if stage_id == 1:
+        return [
+            (None, None),
+            (None, _B(2, 0, 0)),
+            (None, _B(1, 1, 1)),
+            (None, _B(0, 0, -2)),
+            (None, _B(0, 0, 2)),
+            (None, _B(-1, -1, -1)),
+            (None, _B(-2, 0, 0)),
+            (None, _B(2, 2, 2)),
+            (None, _B(0, -2, 0)),
+            (None, _B(0, 2, 0)),
+            (_B(1.01, 1.01, 1.01), None),
+            (_B(0.99, 0.99, 0.99), None),
+        ]
+    if stage_id == 2:
+        defs = [(None, None)]
+        for val in [-4, -3, -2, -1, 1, 2, 3, 4]:
+            defs += [
+                (None, _B(val, val, val)),
+                (None, _B(val, 0, 0)),
+                (None, _B(0, val, 0)),
+                (None, _B(0, 0, val)),
+            ]
+        for frame in [0, 1]:
+            for val in [-2, -1, 1, 2]:
+                for chan, ci in [('all', -1), ('r', 0), ('g', 1), ('b', 2)]:
+                    f0, f1 = [0, 0, 0], [0, 0, 0]
+                    target = f0 if frame == 0 else f1
+                    if ci < 0:
+                        target[0] = target[1] = target[2] = val
+                    else:
+                        target[ci] = val
+                    defs.append((None, _PB(f0, f1)))
+        return defs
+    if stage_id == 3:
+        defs = [(None, None)]
+        for r in [-2, -1, 0, 1, 2]:
+            for g in [-2, -1, 0, 1, 2]:
+                for b in [-2, -1, 0, 1, 2]:
+                    if (r, g, b) != (0, 0, 0):
+                        defs.append((None, _PB((r, g, b), (0, 0, 0))))
+        return defs
+    if stage_id == 4:
+        defs = [(None, None)]
+        for r in [-1, 0, 1]:
+            for g in [-1, 0, 1]:
+                for b in [-1, 0, 1]:
+                    if (r, g, b) != (0, 0, 0):
+                        defs.append((None, _PB((r, g, b), (0, 0, 0))))
+        return defs
+    raise ValueError(f"unknown compact post stage id {stage_id}")
+
+def load_post_codes(data_dir: Path, device: torch.device, encoded_post_codes: bytes | None = None):
+    path = data_dir / "post_codes.br"
+    if encoded_post_codes is None and not path.exists():
+        return None
+    raw = brotli.decompress(encoded_post_codes if encoded_post_codes is not None else path.read_bytes())
+    stages = []
+    if raw[:4] == b"PCD1":
+        pos = 4
+        stage_count = raw[pos]
+        pos += 1
+        for _ in range(stage_count):
+            stage_id = raw[pos]
+            pos += 1
+            n = struct.unpack_from("<H", raw, pos)[0]
+            pos += 2
+            choices = raw[pos:pos+n]
+            pos += n
+            stages.append(_post_stage_from_defs(_post_defs(stage_id), choices, device))
+    else:
+        # Headerless fixed-public-test format: 600 pair choices per stage,
+        # with stage ids implied as 1,2,3[,4].  This saves a few archive bytes
+        # versus a self-describing header; the generic PCD1 path above remains
+        # supported for older artifacts.
+        pairs_per_file = 600
+        if len(raw) % pairs_per_file != 0:
+            raise ValueError("bad headerless post_codes length")
+        stage_count = len(raw) // pairs_per_file
+        if stage_count not in (3, 4):
+            raise ValueError(f"bad headerless post_codes stage count {stage_count}")
+        pos = 0
+        for stage_id in range(1, stage_count + 1):
+            choices = raw[pos:pos+pairs_per_file]
+            pos += pairs_per_file
+            stages.append(_post_stage_from_defs(_post_defs(stage_id), choices, device))
+    return stages or None
+
+def load_postprocess(data_dir: Path, device: torch.device, encoded_post_codes: bytes | None = None):
+    coded_stages = load_post_codes(data_dir, device, encoded_post_codes)
+    if coded_stages is not None:
+        return coded_stages
+
+    def to_pair_tensor(value, default):
+        arr = torch.tensor(value if value is not None else default, dtype=torch.float32, device=device)
+        if arr.ndim == 1:
+            arr = arr.view(1, 1, 1, 3).expand(2, 1, 1, 3)
+        elif arr.ndim == 2 and tuple(arr.shape) == (2, 3):
+            arr = arr.view(2, 1, 1, 3)
+        else:
+            raise ValueError(f"Bad postprocess tensor shape: {tuple(arr.shape)}")
+        return arr
+
+    def build_stage(payload):
+        variants = payload.get("variants", payload.get("v", []))
+        if not variants:
+            return None
+        gains = torch.stack([to_pair_tensor(v.get("gain", v.get("g")), [1.0, 1.0, 1.0]) for v in variants], dim=0)
+        biases = torch.stack([to_pair_tensor(v.get("bias", v.get("b")), [0.0, 0.0, 0.0]) for v in variants], dim=0)
+        choices_data = payload.get("choices", payload.get("c", []))
+        choices = torch.tensor([int(x) for x in choices_data], dtype=torch.long, device=device)
+        return gains, biases, choices
+
+    bundle_path = data_dir / "post_stages.json.br"
+    if bundle_path.exists():
+        bundle = json.loads(brotli.decompress(bundle_path.read_bytes()).decode("utf-8"))
+        stages = []
+        for payload in bundle.get("stages", bundle.get("s", [])):
+            stage = build_stage(payload)
+            if stage is not None:
+                stages.append(stage)
+        return stages or None
+
+    bundle_json_path = data_dir / "post_stages.json"
+    if bundle_json_path.exists():
+        bundle = json.loads(bundle_json_path.read_text(encoding="utf-8"))
+        stages = []
+        for payload in bundle.get("stages", bundle.get("s", [])):
+            stage = build_stage(payload)
+            if stage is not None:
+                stages.append(stage)
+        return stages or None
+
+    stages = []
+    for choices_path in [data_dir / "post_choices.json"] + [data_dir / f"post{i}_choices.json" for i in range(2, 10)]:
+        if not choices_path.exists():
+            continue
+        stage = build_stage(json.loads(choices_path.read_text(encoding="utf-8")))
+        if stage is not None:
+            stages.append(stage)
+    return stages or None
+
+def load_compact_archive_bundle(data_dir: Path):
+    """Load one-file ZIP member used by the smallest packaged variants.
+
+    Member ``x`` stores three little-endian uint32 lengths followed by the
+    brotli-compressed mask, model, pose, and post-code payloads.  Keeping these
+    already-compressed blobs in one ZIP member avoids three ZIP local/central
+    headers and long member names.
+    """
+    path = data_dir / "x"
+    if not path.exists():
+        return None
+    raw = path.read_bytes()
+    if len(raw) < 9:
+        raise ValueError("bad compact archive bundle")
+
+    def parse_at(pos, l_mask, l_model, l_pose):
+        mask = raw[pos:pos + l_mask]
+        pos += l_mask
+        model = raw[pos:pos + l_model]
+        pos += l_model
+        pose = raw[pos:pos + l_pose]
+        pos += l_pose
+        post = raw[pos:]
+        if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and post:
+            return {"mask": mask, "model": model, "pose": pose, "post": post}
+        return None
+
+    # Preferred v4/v3/v2 header: 24-bit little-endian lengths.  v4 adds
+    # an explicit shift length and a fractional-shift tail.
+    l_mask = int.from_bytes(raw[0:3], "little")
+    l_model = int.from_bytes(raw[3:6], "little")
+    l_pose = int.from_bytes(raw[6:9], "little")
+    if len(raw) >= 30:
+        l_post = int.from_bytes(raw[9:12], "little")
+        l_shift = int.from_bytes(raw[12:15], "little")
+        l_frac = int.from_bytes(raw[15:18], "little")
+        l_frac2 = int.from_bytes(raw[18:21], "little")
+        l_frac3 = int.from_bytes(raw[21:24], "little")
+        l_bias = int.from_bytes(raw[24:27], "little")
+        l_region = int.from_bytes(raw[27:30], "little")
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000 and 0 < l_shift < 10000 and 0 < l_frac < 10000 and 0 < l_frac2 < 10000 and 0 < l_frac3 < 10000 and 0 < l_bias < 10000 and 0 < l_region < 10000:
+            pos = 30
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:pos + l_shift]; pos += l_shift
+            frac = raw[pos:pos + l_frac]; pos += l_frac
+            frac2 = raw[pos:pos + l_frac2]; pos += l_frac2
+            frac3 = raw[pos:pos + l_frac3]; pos += l_frac3
+            bias = raw[pos:pos + l_bias]; pos += l_bias
+            region = raw[pos:pos + l_region]; pos += l_region
+            randmulti = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and len(shift) == l_shift and len(frac) == l_frac and len(frac2) == l_frac2 and len(frac3) == l_frac3 and len(bias) == l_bias and len(region) == l_region and randmulti:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": frac, "frac2": frac2, "frac3": frac3, "bias": bias, "region": region, "randmulti": randmulti}
+    if len(raw) >= 27:
+        l_post = int.from_bytes(raw[9:12], "little")
+        l_shift = int.from_bytes(raw[12:15], "little")
+        l_frac = int.from_bytes(raw[15:18], "little")
+        l_frac2 = int.from_bytes(raw[18:21], "little")
+        l_frac3 = int.from_bytes(raw[21:24], "little")
+        l_bias = int.from_bytes(raw[24:27], "little")
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000 and 0 < l_shift < 10000 and 0 < l_frac < 10000 and 0 < l_frac2 < 10000 and 0 < l_frac3 < 10000 and 0 < l_bias < 10000:
+            pos = 27
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:pos + l_shift]; pos += l_shift
+            frac = raw[pos:pos + l_frac]; pos += l_frac
+            frac2 = raw[pos:pos + l_frac2]; pos += l_frac2
+            frac3 = raw[pos:pos + l_frac3]; pos += l_frac3
+            bias = raw[pos:pos + l_bias]; pos += l_bias
+            region = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and len(shift) == l_shift and len(frac) == l_frac and len(frac2) == l_frac2 and len(frac3) == l_frac3 and len(bias) == l_bias and region:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": frac, "frac2": frac2, "frac3": frac3, "bias": bias, "region": region}
+    # v5 micro header: omit l_bias/l_region from archive and keep these fixed in code.
+    # This saves 6 archive bytes for the fixed current bundle layout.
+    if len(raw) >= 24:
+        l_post = int.from_bytes(raw[9:12], "little")
+        l_shift = int.from_bytes(raw[12:15], "little")
+        l_frac = int.from_bytes(raw[15:18], "little")
+        l_frac2 = int.from_bytes(raw[18:21], "little")
+        l_frac3 = int.from_bytes(raw[21:24], "little")
+        l_bias = 223
+        l_region = 273
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000 and 0 < l_shift < 10000 and 0 < l_frac < 10000 and 0 < l_frac2 < 10000 and 0 < l_frac3 < 10000:
+            pos = 24
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:pos + l_shift]; pos += l_shift
+            frac = raw[pos:pos + l_frac]; pos += l_frac
+            frac2 = raw[pos:pos + l_frac2]; pos += l_frac2
+            frac3 = raw[pos:pos + l_frac3]; pos += l_frac3
+            bias = raw[pos:pos + l_bias]; pos += l_bias
+            region = raw[pos:pos + l_region]; pos += l_region
+            randmulti = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and len(shift) == l_shift and len(frac) == l_frac and len(frac2) == l_frac2 and len(frac3) == l_frac3 and len(bias) == l_bias and len(region) == l_region and randmulti:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": frac, "frac2": frac2, "frac3": frac3, "bias": bias, "region": region, "randmulti": randmulti}
+    if len(raw) >= 24:
+        l_post = int.from_bytes(raw[9:12], "little")
+        l_shift = int.from_bytes(raw[12:15], "little")
+        l_frac = int.from_bytes(raw[15:18], "little")
+        l_frac2 = int.from_bytes(raw[18:21], "little")
+        l_frac3 = int.from_bytes(raw[21:24], "little")
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000 and 0 < l_shift < 10000 and 0 < l_frac < 10000 and 0 < l_frac2 < 10000 and 0 < l_frac3 < 10000:
+            pos = 24
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:pos + l_shift]; pos += l_shift
+            frac = raw[pos:pos + l_frac]; pos += l_frac
+            frac2 = raw[pos:pos + l_frac2]; pos += l_frac2
+            frac3 = raw[pos:pos + l_frac3]; pos += l_frac3
+            bias = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and len(shift) == l_shift and len(frac) == l_frac and len(frac2) == l_frac2 and len(frac3) == l_frac3 and bias:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": frac, "frac2": frac2, "frac3": frac3, "bias": bias}
+    if len(raw) >= 21:
+        l_post = int.from_bytes(raw[9:12], "little")
+        l_shift = int.from_bytes(raw[12:15], "little")
+        l_frac = int.from_bytes(raw[15:18], "little")
+        l_frac2 = int.from_bytes(raw[18:21], "little")
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000 and 0 < l_shift < 10000 and 0 < l_frac < 10000 and 0 < l_frac2 < 10000:
+            pos = 21
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:pos + l_shift]; pos += l_shift
+            frac = raw[pos:pos + l_frac]; pos += l_frac
+            frac2 = raw[pos:pos + l_frac2]; pos += l_frac2
+            frac3 = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and len(shift) == l_shift and len(frac) == l_frac and len(frac2) == l_frac2 and frac3:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": frac, "frac2": frac2, "frac3": frac3}
+    if len(raw) >= 18:
+        l_post = int.from_bytes(raw[9:12], "little")
+        l_shift = int.from_bytes(raw[12:15], "little")
+        l_frac = int.from_bytes(raw[15:18], "little")
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000 and 0 < l_shift < 10000 and 0 < l_frac < 10000:
+            pos = 18
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:pos + l_shift]; pos += l_shift
+            frac = raw[pos:pos + l_frac]; pos += l_frac
+            frac2 = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and len(shift) == l_shift and len(frac) == l_frac and frac2:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": frac, "frac2": frac2}
+    if len(raw) >= 15:
+        l_post = int.from_bytes(raw[9:12], "little")
+        l_shift = int.from_bytes(raw[12:15], "little")
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000 and 0 < l_shift < 10000:
+            pos = 15
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:pos + l_shift]; pos += l_shift
+            frac = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and len(shift) == l_shift and frac:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": frac}
+    if len(raw) >= 12:
+        l_post = int.from_bytes(raw[9:12], "little")
+        if l_mask > 1000 and l_model > 1000 and l_pose > 100 and 0 < l_post < 10000:
+            pos = 12
+            mask = raw[pos:pos + l_mask]; pos += l_mask
+            model = raw[pos:pos + l_model]; pos += l_model
+            pose = raw[pos:pos + l_pose]; pos += l_pose
+            post = raw[pos:pos + l_post]; pos += l_post
+            shift = raw[pos:]
+            if len(mask) == l_mask and len(model) == l_model and len(pose) == l_pose and len(post) == l_post and shift:
+                return {"mask": mask, "model": model, "pose": pose, "post": post, "shift": shift, "frac": b""}
+    if l_mask > 1000 and l_model > 1000 and l_pose > 100:
+        parsed = parse_at(9, l_mask, l_model, l_pose)
+        if parsed is not None:
+            parsed["shift"] = b""
+            parsed["frac"] = b""
+            return parsed
+
+    # Older v1 header: three uint32 lengths.
+    if len(raw) < 12:
+        raise ValueError("bad compact archive bundle")
+    l_mask, l_model, l_pose = struct.unpack_from("<III", raw, 0)
+    pos = 12
+    mask = raw[pos:pos + l_mask]
+    pos += l_mask
+    model = raw[pos:pos + l_model]
+    pos += l_model
+    pose = raw[pos:pos + l_pose]
+    pos += l_pose
+    post = raw[pos:]
+    if len(mask) != l_mask or len(model) != l_model or len(pose) != l_pose or not post:
+        raise ValueError("truncated compact archive bundle")
+    return {"mask": mask, "model": model, "pose": pose, "post": post}
+
+def load_ablation_config(data_dir: Path):
+    path = data_dir / "ablation.json"
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+def parse_local_actions(data: bytes):
+    if not data:
+        return None, None
+    if data.startswith(COMPOSITE_ACTION_MAGIC):
+        if len(data) < 12:
+            raise RuntimeError("truncated RMC1 local action payload")
+        seg_len = int.from_bytes(data[4:8], "little")
+        side_len = int.from_bytes(data[8:12], "little")
+        offset = 12
+        end = offset + seg_len + side_len
+        if end != len(data):
+            raise RuntimeError(f"RMC1 local action length mismatch: header={end} actual={len(data)}")
+        seg = data[offset : offset + seg_len] or None
+        side = data[offset + seg_len : end] or None
+        return seg, side
+    if len(data) == ROUTER_ACTION_BYTES or data.startswith(SIDE_ACTION_MAGIC) or data.startswith(SIDE_ACTION_BROTLI_MAGIC):
+        return None, data
+    return data, None
+
+def seg_tile_action_specs(device: torch.device):
+    specs = []
+    directions = [
+        (1.0, 1.0, 1.0),
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
+        (1.0, 1.0, 0.0),
+        (0.0, 1.0, 1.0),
+        (1.0, 0.0, 1.0),
+        (-0.35, 0.15, 0.45),
+        (0.25, 0.15, -0.20),
+    ]
+    for vec in directions:
+        v = torch.tensor(vec, dtype=torch.float32, device=device).view(3, 1, 1)
+        v = v / v.abs().max().clamp_min(1e-6)
+        for amp in (2.0, 4.0, 6.0, 8.0, 12.0, 16.0):
+            specs.append(v * amp)
+            specs.append(-v * amp)
+    return torch.stack(specs, dim=0)
+
+def load_seg_tile_actions_data(data: bytes, device: torch.device):
+    raw = brotli.decompress(data)
+    records = []
+
+    def read_uvarint(cursor: int) -> tuple[int, int]:
+        shift = 0
+        value = 0
+        while True:
+            byte = raw[cursor]
+            cursor += 1
+            value |= (byte & 0x7F) << shift
+            if byte < 0x80:
+                return value, cursor
+            shift += 7
+
+    if raw.startswith(b"SG2") or (len(raw) % 4 != 0 and len(raw) % 5 != 0):
+        cursor = 3 if raw.startswith(b"SG2") else 0
+        while cursor < len(raw):
+            tile, cursor = read_uvarint(cursor)
+            count, cursor = read_uvarint(cursor)
+            frame = 0
+            for i in range(count):
+                delta, cursor = read_uvarint(cursor)
+                frame = delta if i == 0 else frame + delta
+                action = raw[cursor]
+                cursor += 1
+                records.append((frame, tile, action))
+    elif len(raw) % 4 == 0:
+        for i in range(0, len(raw), 4):
+            frame = int.from_bytes(raw[i:i + 2], "little")
+            tile = raw[i + 2]
+            action = raw[i + 3]
+            records.append((frame, tile, action))
+    elif len(raw) % 5 == 0:
+        for i in range(0, len(raw), 5):
+            frame = int.from_bytes(raw[i:i + 2], "little")
+            tile = int.from_bytes(raw[i + 2:i + 4], "little")
+            action = raw[i + 4]
+            records.append((frame, tile, action))
+    elif len(raw) != 0:
+        raise ValueError(f"unsupported seg tile action payload length: {len(raw)}")
+    by_frame = {}
+    for frame, tile, action in records:
+        by_frame.setdefault(frame, []).append((tile, action))
+    return {"by_frame": by_frame, "deltas": seg_tile_action_specs(device)}
+
+def unpack_router_actions(action_payload: bytes, count: int = ROUTER_ACTION_COUNT) -> tuple[torch.Tensor, int]:
+    table_id = 0
+    action_bits = ROUTER_ACTION_BITS
+    offset = 0
+    if action_payload.startswith(SIDE_ACTION_BROTLI_MAGIC):
+        if len(action_payload) < 8:
+            raise RuntimeError("truncated RSB1 side-action payload")
+        count = int.from_bytes(action_payload[4:6], "little")
+        table_id = action_payload[6]
+        raw = brotli.decompress(action_payload[8:])
+        if len(raw) != count:
+            raise RuntimeError(f"decoded {len(raw)} RSB1 actions, expected {count}")
+        return torch.tensor(list(raw), dtype=torch.uint8), table_id
+    if action_payload.startswith(SIDE_ACTION_MAGIC):
+        if len(action_payload) < 8:
+            raise RuntimeError("truncated RSA1 side-action payload")
+        count = int.from_bytes(action_payload[4:6], "little")
+        action_bits = action_payload[6]
+        table_id = action_payload[7]
+        offset = 8
+        if action_bits <= 0 or action_bits > 8:
+            raise RuntimeError(f"unsupported RSA1 action bit width: {action_bits}")
+    elif len(action_payload) != ROUTER_ACTION_BYTES:
+        raise RuntimeError(f"unexpected router action payload length: {len(action_payload)}")
+    vals = []
+    acc = 0
+    bits = 0
+    mask = (1 << action_bits) - 1
+    for byte in action_payload[offset:]:
+        acc |= int(byte) << bits
+        bits += 8
+        while bits >= action_bits and len(vals) < count:
+            vals.append(acc & mask)
+            acc >>= action_bits
+            bits -= action_bits
+    if len(vals) != count:
+        raise RuntimeError(f"decoded {len(vals)} router actions, expected {count}")
+    return torch.tensor(vals, dtype=torch.uint8), table_id
+
+def shift_frame_chw(frames: torch.Tensor, dx: int, dy: int) -> torch.Tensor:
+    if dx == 0 and dy == 0:
+        return frames
+    left = max(dx, 0)
+    right = max(-dx, 0)
+    top = max(dy, 0)
+    bottom = max(-dy, 0)
+    padded = F.pad(frames, (left, right, top, bottom), mode="replicate")
+    y0 = bottom
+    x0 = right
+    return padded[:, :, y0 : y0 + frames.shape[-2], x0 : x0 + frames.shape[-1]]
+
+def apply_router_actions(batch_comp: torch.Tensor, actions: torch.Tensor, table_id: int = 0) -> torch.Tensor:
+    if actions.numel() == 0:
+        return batch_comp
+    out = batch_comp.clamp(0, 255).round()
+    actions = actions.to(device=out.device, dtype=torch.long)
+
+    def select(action_id: int) -> torch.Tensor:
+        return actions == action_id
+
+    mask = select(1)
+    if mask.any():
+        out[mask, 1, 2:3] = (out[mask, 1, 2:3] - 3.0).clamp(0, 255).round()
+    mask = select(2)
+    if mask.any():
+        out[mask, :, 1:2] = (out[mask, :, 1:2] - 3.0).clamp(0, 255).round()
+    mask = select(3)
+    if mask.any():
+        out[mask] = (out[mask] - 2.0).clamp(0, 255).round()
+    mask = select(4)
+    if mask.any():
+        out[mask, 1:2] = ((out[mask, 1:2] - 128.0) * 1.03 + 128.0).clamp(0, 255).round()
+    mask = select(5)
+    if mask.any():
+        out[mask, 1, 0:1] = (out[mask, 1, 0:1] + 3.0).clamp(0, 255).round()
+    mask = select(6)
+    if mask.any():
+        out[mask, 1, 1:2] = (out[mask, 1, 1:2] - 4.0).clamp(0, 255).round()
+    mask = select(7)
+    if mask.any():
+        out[mask] = torch.pow((out[mask] / 255.0).clamp(0.0, 1.0), 1.04).mul(255.0).clamp(0, 255).round()
+    if table_id == 0:
+        return out
+
+    mask = select(8)
+    if mask.any():
+        out[mask, 0, 0:1] = (out[mask, 0, 0:1] + 2.0).clamp(0, 255).round()
+    mask = select(9)
+    if mask.any():
+        out[mask, 0, 0:1] = (out[mask, 0, 0:1] - 2.0).clamp(0, 255).round()
+    mask = select(10)
+    if mask.any():
+        out[mask, 0, 1:2] = (out[mask, 0, 1:2] + 2.0).clamp(0, 255).round()
+    mask = select(11)
+    if mask.any():
+        out[mask, 0, 1:2] = (out[mask, 0, 1:2] - 2.0).clamp(0, 255).round()
+    mask = select(12)
+    if mask.any():
+        out[mask, 0, 2:3] = (out[mask, 0, 2:3] + 2.0).clamp(0, 255).round()
+    mask = select(13)
+    if mask.any():
+        out[mask, 0, 2:3] = (out[mask, 0, 2:3] - 2.0).clamp(0, 255).round()
+    mask = select(14)
+    if mask.any():
+        out[mask, 1, 0:1] = (out[mask, 1, 0:1] - 3.0).clamp(0, 255).round()
+    mask = select(15)
+    if mask.any():
+        out[mask, 1, 2:3] = (out[mask, 1, 2:3] + 3.0).clamp(0, 255).round()
+    mask = select(16)
+    if mask.any():
+        out[mask, 1:2] = (out[mask, 1:2] + 1.0).clamp(0, 255).round()
+    mask = select(17)
+    if mask.any():
+        out[mask, 1:2] = (out[mask, 1:2] - 1.0).clamp(0, 255).round()
+    mask = select(18)
+    if mask.any():
+        out[mask, 0:1] = (out[mask, 0:1] + 1.0).clamp(0, 255).round()
+    mask = select(19)
+    if mask.any():
+        out[mask, 0:1] = (out[mask, 0:1] - 1.0).clamp(0, 255).round()
+    mask = select(20)
+    if mask.any():
+        out[mask] = (out[mask] + 1.0).clamp(0, 255).round()
+    mask = select(21)
+    if mask.any():
+        out[mask] = (out[mask] - 1.0).clamp(0, 255).round()
+    mask = select(22)
+    if mask.any():
+        out[mask] = ((out[mask] - 128.0) * 0.98 + 128.0).clamp(0, 255).round()
+    mask = select(23)
+    if mask.any():
+        out[mask, 1:2] = ((out[mask, 1:2] - 128.0) * 0.98 + 128.0).clamp(0, 255).round()
+    mask = select(24)
+    if mask.any():
+        out[mask, 0:1] = ((out[mask, 0:1] - 128.0) * 1.02 + 128.0).clamp(0, 255).round()
+    mask = select(25)
+    if mask.any():
+        out[mask, 0:1] = ((out[mask, 0:1] - 128.0) * 0.98 + 128.0).clamp(0, 255).round()
+    for action_id, frame_idx, dx, dy in (
+        (26, 1, 1, 0),
+        (27, 1, -1, 0),
+        (28, 1, 0, 1),
+        (29, 1, 0, -1),
+        (30, 0, 1, 0),
+        (31, 0, -1, 0),
+    ):
+        mask = select(action_id)
+        if mask.any():
+            out[mask, frame_idx] = shift_frame_chw(out[mask, frame_idx], dx, dy)
+    mask = select(32)
+    if mask.any():
+        out[mask, 1, :, 112:384, 160:352] = (out[mask, 1, :, 112:384, 160:352] + 2.0).clamp(0, 255).round()
+    mask = select(33)
+    if mask.any():
+        out[mask, 1, :, 112:384, 160:352] = (out[mask, 1, :, 112:384, 160:352] - 2.0).clamp(0, 255).round()
+    mask = select(34)
+    if mask.any():
+        out[mask, 1, 1:2, 112:384, 160:352] = (out[mask, 1, 1:2, 112:384, 160:352] - 2.0).clamp(0, 255).round()
+    mask = select(35)
+    if mask.any():
+        out[mask, 1, 2:3, 112:384, 160:352] = (out[mask, 1, 2:3, 112:384, 160:352] - 2.0).clamp(0, 255).round()
+    mask = select(36)
+    if mask.any():
+        out[mask, 1, :, 224:384, :] = (out[mask, 1, :, 224:384, :] + 2.0).clamp(0, 255).round()
+    mask = select(37)
+    if mask.any():
+        out[mask, 1, :, 224:384, :] = (out[mask, 1, :, 224:384, :] - 2.0).clamp(0, 255).round()
+    mask = select(38)
+    if mask.any():
+        out[mask, 0, :, 112:384, 160:352] = (out[mask, 0, :, 112:384, 160:352] + 2.0).clamp(0, 255).round()
+    mask = select(39)
+    if mask.any():
+        out[mask, 0, :, 112:384, 160:352] = (out[mask, 0, :, 112:384, 160:352] - 2.0).clamp(0, 255).round()
+    mask = select(40)
+    if mask.any():
+        out[mask] = torch.pow((out[mask] / 255.0).clamp(0.0, 1.0), 0.98).mul(255.0).clamp(0, 255).round()
+    mask = select(41)
+    if mask.any():
+        out[mask, 1:2] = torch.pow((out[mask, 1:2] / 255.0).clamp(0.0, 1.0), 0.98).mul(255.0).clamp(0, 255).round()
+    mask = select(42)
+    if mask.any():
+        out[mask, 0:1] = torch.pow((out[mask, 0:1] / 255.0).clamp(0.0, 1.0), 1.04).mul(255.0).clamp(0, 255).round()
+    mask = select(43)
+    if mask.any():
+        out[mask, 0:1] = torch.pow((out[mask, 0:1] / 255.0).clamp(0.0, 1.0), 0.98).mul(255.0).clamp(0, 255).round()
+    mask = select(44)
+    if mask.any():
+        out[mask, :, 0:1] = (out[mask, :, 0:1] + 1.0).clamp(0, 255).round()
+    mask = select(45)
+    if mask.any():
+        out[mask, :, 2:3] = (out[mask, :, 2:3] - 1.0).clamp(0, 255).round()
+    mask = select(46)
+    if mask.any():
+        out[mask, 1:2] = ((out[mask, 1:2] - 128.0) * 1.01 + 128.0).clamp(0, 255).round()
+    mask = select(47)
+    if mask.any():
+        out[mask, 1:2] = ((out[mask, 1:2] - 128.0) * 0.99 + 128.0).clamp(0, 255).round()
+    mask = select(48)
+    if mask.any():
+        out[mask, 1, 2:3, 112:384, 160:352] = (out[mask, 1, 2:3, 112:384, 160:352] - 1.0).clamp(0, 255).round()
+    mask = select(49)
+    if mask.any():
+        out[mask, 1, 2:3, 112:384, 160:352] = (out[mask, 1, 2:3, 112:384, 160:352] - 3.0).clamp(0, 255).round()
+    mask = select(50)
+    if mask.any():
+        out[mask, 1, 1:2, 112:384, 160:352] = (out[mask, 1, 1:2, 112:384, 160:352] - 1.0).clamp(0, 255).round()
+    mask = select(51)
+    if mask.any():
+        out[mask, 1, 1:2, 112:384, 160:352] = (out[mask, 1, 1:2, 112:384, 160:352] - 3.0).clamp(0, 255).round()
+    mask = select(52)
+    if mask.any():
+        out[mask, 1, :, 112:384, 160:352] = (out[mask, 1, :, 112:384, 160:352] - 1.0).clamp(0, 255).round()
+    mask = select(53)
+    if mask.any():
+        out[mask, 1, :, 112:384, 160:352] = (out[mask, 1, :, 112:384, 160:352] - 3.0).clamp(0, 255).round()
+    mask = select(54)
+    if mask.any():
+        out[mask, 0, 0:1] = (out[mask, 0, 0:1] + 1.0).clamp(0, 255).round()
+    mask = select(55)
+    if mask.any():
+        out[mask, 0, 0:1] = (out[mask, 0, 0:1] + 3.0).clamp(0, 255).round()
+    mask = select(56)
+    if mask.any():
+        out[mask, 0, 0:1] = (out[mask, 0, 0:1] - 1.0).clamp(0, 255).round()
+    mask = select(57)
+    if mask.any():
+        out[mask, 0, 0:1] = (out[mask, 0, 0:1] - 3.0).clamp(0, 255).round()
+    mask = select(58)
+    if mask.any():
+        out[mask, 0, 2:3] = (out[mask, 0, 2:3] + 1.0).clamp(0, 255).round()
+    mask = select(59)
+    if mask.any():
+        out[mask, 0, 2:3] = (out[mask, 0, 2:3] + 3.0).clamp(0, 255).round()
+    mask = select(60)
+    if mask.any():
+        out[mask, 0, 2:3] = (out[mask, 0, 2:3] - 1.0).clamp(0, 255).round()
+    mask = select(61)
+    if mask.any():
+        out[mask, 0, 2:3] = (out[mask, 0, 2:3] - 3.0).clamp(0, 255).round()
+    mask = select(62)
+    if mask.any():
+        out[mask, 1, 2:3] = (out[mask, 1, 2:3] - 1.0).clamp(0, 255).round()
+    mask = select(63)
+    if mask.any():
+        out[mask, 1, 2:3] = (out[mask, 1, 2:3] + 1.0).clamp(0, 255).round()
+    return out
+
+def decode_randmulti_bitmask_payload(encoded: bytes) -> bytes:
+    if len(encoded) < 6 or encoded[:4] != b"RMB1":
+        raise ValueError("bad RMB1 randmulti payload")
+    mask_len = int.from_bytes(encoded[4:6], "little")
+    mask_br = encoded[6 : 6 + mask_len]
+    vals_br = encoded[6 + mask_len :]
+    mask = brotli.decompress(mask_br)
+    vals = brotli.decompress(vals_br)
+    if len(mask) % 75:
+        raise ValueError("bad RMB1 mask length")
+
+    out = bytearray()
+    vals_pos = 0
+    for row_start in range(0, len(mask), 75):
+        row_mask = mask[row_start : row_start + 75]
+        inds = []
+        row_vals = []
+        for byte_i, byte in enumerate(row_mask):
+            for bit in range(8):
+                frame_i = byte_i * 8 + bit
+                if frame_i >= 600:
+                    break
+                if byte & (1 << bit):
+                    if vals_pos >= len(vals):
+                        raise ValueError("truncated RMB1 values")
+                    inds.append(frame_i)
+                    row_vals.append(vals[vals_pos])
+                    vals_pos += 1
+        cnt = len(inds)
+        if cnt < 255:
+            out.append(cnt)
+        else:
+            out.append(255)
+            out.extend(cnt.to_bytes(2, "little"))
+        last = -1
+        for idx in inds:
+            delta = idx - last - 1
+            last = idx
+            while True:
+                byte = delta & 0x7F
+                delta >>= 7
+                if delta:
+                    out.append(byte | 0x80)
+                else:
+                    out.append(byte)
+                    break
+        out.extend(row_vals)
+    if vals_pos != len(vals):
+        raise ValueError("unused RMB1 values")
+    return bytes(out)
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: python inflate.py <data_dir> <output_dir> <file_list_txt>")
+        sys.exit(1)
+
+    data_dir = Path(sys.argv[1])
+    out_dir = Path(sys.argv[2])
+    file_list_path = Path(sys.argv[3])
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    files = [line.strip() for line in file_list_path.read_text().splitlines() if line.strip()]
+
+    bundle = load_compact_archive_bundle(data_dir)
+    ablation = load_ablation_config(data_dir)
+    local_actions_path = data_dir / "a"
+    local_seg_actions_data = None
+    local_router_actions_data = None
+    if local_actions_path.exists():
+        local_seg_actions_data, local_router_actions_data = parse_local_actions(local_actions_path.read_bytes())
+    if bundle is not None and ablation:
+        for name in ablation.get("drop_streams", []):
+            if name in bundle:
+                bundle[name] = b""
+    model_br = data_dir / "model.pt.br"
+    mask_br = data_dir / "mask.obu.br"
+    pose_br = data_dir / "pose.npy.br"
+
+    generator = JointFrameGenerator().to(device)
+
+    # 1. Load Weights
+    if bundle is not None:
+        weights_data = brotli.decompress(bundle["model"])
+    else:
+        with open(model_br, "rb") as f:
+            weights_data = brotli.decompress(f.read())
+
+    generator.load_state_dict(get_decoded_state_dict(weights_data, device), strict=True)
+    generator.eval()
+
+    # 2. Load Mask Video (.obu) or exact qzs3 range-coded class tensor.
+    if bundle is not None and bundle["mask"][:4] in (b"QMA6", b"QMA7", b"QMA8", b"QMA9"):
+        mask_frames_all = load_range_mask(bundle["mask"])
+    else:
+        with tempfile.NamedTemporaryFile(suffix=".obu", delete=False) as tmp_obu:
+            if bundle is not None:
+                tmp_obu.write(brotli.decompress(bundle["mask"]))
+            else:
+                with open(mask_br, "rb") as f:
+                    tmp_obu.write(brotli.decompress(f.read()))
+            tmp_obu_path = tmp_obu.name
+        mask_frames_all = load_encoded_mask_video(tmp_obu_path)
+        os.remove(tmp_obu_path)
+
+    # 3. Load Pose Vectors
+    pose_frames_all = load_pose_frames_from_payload(bundle["pose"]) if bundle is not None else load_pose_frames(pose_br)
+    post_payload = None if ablation.get("disable_post") else (bundle["post"] if bundle is not None else None)
+    postprocess = load_postprocess(data_dir, device, post_payload)
+    f0_shift_choices = None
+    f1_frac_choices = None
+    f1_frac2_choices = None
+    f1_frac3_choices = None
+    f1_bias_choices = None
+    f1_region_choices = None
+    f1_randmulti_choices = None
+    if bundle is not None and len(bundle.get("shift", b"")):
+        raw_s = brotli.decompress(bundle["shift"])
+        magic = raw_s[:3]
+        if magic == b"SH4":
+            arr = np.frombuffer(raw_s, dtype=np.uint8, offset=3).astype(np.int64)
+        elif magic == b"SD4":
+            d = np.frombuffer(raw_s, dtype=np.uint8, offset=3).astype(np.int64)
+            arr = np.where(d == 0, 40, d - 1).astype(np.int64)
+        else:
+            raise ValueError("bad f1 shift payload")
+        f0_shift_choices = torch.from_numpy(arr).to(device)
+    if bundle is not None and len(bundle.get("frac", b"")):
+        raw_f = brotli.decompress(bundle["frac"])
+        magic_f = raw_f[:3]
+        if magic_f == b"FH1":
+            arr_f = np.frombuffer(raw_f, dtype=np.uint8, offset=3).astype(np.int64)
+        elif magic_f == b"FV1":
+            cnt = int.from_bytes(raw_f[3:5], "little")
+            pos_f = 5; arr_f = np.full(600, 4, dtype=np.int64); idx_f = -1; inds = []
+            for _ in range(cnt):
+                acc = 0; sh = 0
+                while True:
+                    by = raw_f[pos_f]; pos_f += 1; acc |= (by & 127) << sh
+                    if by & 128: sh += 7
+                    else: break
+                idx_f += acc + 1; inds.append(idx_f)
+            vals_f = np.frombuffer(raw_f, dtype=np.uint8, count=cnt, offset=pos_f).astype(np.int64)
+            for ii, vv in zip(inds, vals_f): arr_f[ii] = vv - 1
+        else:
+            raise ValueError("bad f1 fractional shift payload")
+        f1_frac_choices = torch.from_numpy(arr_f).to(device)
+    if bundle is not None and len(bundle.get("frac2", b"")):
+        raw_f2 = brotli.decompress(bundle["frac2"])
+        if raw_f2[:3] != b"FH2":
+            raise ValueError("bad f1 fractional shift2 payload")
+        f1_frac2_choices = torch.from_numpy(np.frombuffer(raw_f2, dtype=np.uint8, offset=3).astype(np.int64)).to(device)
+    if bundle is not None and len(bundle.get("frac3", b"")):
+        raw_f3 = brotli.decompress(bundle["frac3"])
+        magic3 = raw_f3[:3]
+        if magic3 == b"FH3":
+            arr3 = np.frombuffer(raw_f3, dtype=np.uint8, offset=3).astype(np.int64)
+        elif magic3 == b"FD3":
+            d3 = np.frombuffer(raw_f3, dtype=np.uint8, offset=3).astype(np.int64)
+            arr3 = np.where(d3 == 0, 4, d3 - 1).astype(np.int64)
+        else:
+            raise ValueError("bad f1 fractional shift3 payload")
+        f1_frac3_choices = torch.from_numpy(arr3).to(device)
+    if bundle is not None and len(bundle.get("bias", b"")):
+        raw_b = brotli.decompress(bundle["bias"])
+        magic_b = raw_b[:3]
+        center_b = 13
+        if magic_b == b"BH1":
+            arr_b = np.frombuffer(raw_b, dtype=np.uint8, offset=3).astype(np.int64)
+        elif magic_b == b"BD1":
+            d_b = np.frombuffer(raw_b, dtype=np.uint8, offset=3).astype(np.int64)
+            arr_b = np.where(d_b == 0, center_b, d_b - 1).astype(np.int64)
+        elif magic_b == b"BV1":
+            cnt_b = int.from_bytes(raw_b[3:5], "little")
+            pos_b = 5; arr_b = np.full(600, center_b, dtype=np.int64); idx_b = -1; inds_b = []
+            for _ in range(cnt_b):
+                acc = 0; sh = 0
+                while True:
+                    by = raw_b[pos_b]; pos_b += 1; acc |= (by & 127) << sh
+                    if by & 128: sh += 7
+                    else: break
+                idx_b += acc + 1; inds_b.append(idx_b)
+            vals_b = np.frombuffer(raw_b, dtype=np.uint8, count=cnt_b, offset=pos_b).astype(np.int64)
+            for ii, vv in zip(inds_b, vals_b): arr_b[ii] = vv - 1
+        else:
+            raise ValueError("bad f1 RGB bias payload")
+        f1_bias_choices = torch.from_numpy(arr_b).to(device)
+    if bundle is not None and len(bundle.get("region", b"")):
+        raw_r = brotli.decompress(bundle["region"])
+        magic_r = raw_r[:3]
+        if magic_r == b"RH1":
+            arr_r = np.frombuffer(raw_r, dtype=np.uint8, offset=3).astype(np.int64)
+        elif magic_r == b"RD1":
+            d_r = np.frombuffer(raw_r, dtype=np.uint8, offset=3).astype(np.int64)
+            arr_r = np.where(d_r == 0, 0, d_r - 1).astype(np.int64)
+        elif magic_r == b"RV1":
+            cnt_r = int.from_bytes(raw_r[3:5], "little")
+            pos_r = 5; arr_r = np.zeros(600, dtype=np.int64); idx_r = -1; inds_r = []
+            for _ in range(cnt_r):
+                acc = 0; sh = 0
+                while True:
+                    by = raw_r[pos_r]; pos_r += 1; acc |= (by & 127) << sh
+                    if by & 128: sh += 7
+                    else: break
+                idx_r += acc + 1; inds_r.append(idx_r)
+            vals_r = np.frombuffer(raw_r, dtype=np.uint8, count=cnt_r, offset=pos_r).astype(np.int64)
+            for ii, vv in zip(inds_r, vals_r): arr_r[ii] = vv - 1
+        else:
+            raise ValueError("bad f1 region-bias payload")
+        f1_region_choices = torch.from_numpy(arr_r).to(device)
+    if bundle is not None and len(bundle.get("randmulti", b"")):
+        encoded_randmulti = bundle["randmulti"]
+        raw_n = decode_randmulti_bitmask_payload(encoded_randmulti) if encoded_randmulti[:4] == b"RMB1" else brotli.decompress(encoded_randmulti)
+        f1_randmulti_choices = []
+        if raw_n[:3] == b"NM1":
+            scount = int(raw_n[3])
+            arr_n = np.frombuffer(raw_n, dtype=np.uint8, count=scount * 600, offset=4).reshape(scount, 600).astype(np.int64)
+            f1_randmulti_choices.append((torch.from_numpy(arr_n).to(device), 24, 32, 1))
+        elif raw_n[:3] == b"NM2":
+            pos_n = 4
+            gcount = int(raw_n[3])
+            for _ in range(gcount):
+                lh_n = int(raw_n[pos_n]); lw_n = int(raw_n[pos_n + 1]); amp_n = int(raw_n[pos_n + 2]); scount = int(raw_n[pos_n + 3]); pos_n += 4
+                arr_n = np.frombuffer(raw_n, dtype=np.uint8, count=scount * 600, offset=pos_n).reshape(scount, 600).astype(np.int64)
+                pos_n += scount * 600
+                f1_randmulti_choices.append((torch.from_numpy(arr_n).to(device), lh_n, lw_n, amp_n))
+        else:
+            specs_n = [(24, 32, 1, 12), (12, 16, 1, 1), (6, 8, 1, 1), (3, 4, 1, 1), (2, 2, 1, 1), (8, 8, 1, 1), (4, 4, 1, 1), (4, 8, 1, 1), (2, 4, 1, 1), (2, 8, 1, 1), (1, 2, 1, 1), (1, 4, 1, 1), (2, 1, 1, 1), (4, 1, 1, 1), (8, 1, 1, 1), (1, 8, 1, 1), (16, 1, 1, 1), (1, 16, 1, 1), (32, 1, 1, 1), (64, 1, 1, 1), (256, 1, 1, 1), (1024, 1, 1, 1), (2048, 1, 1, 1), (4096, 1, 1, 1), (8192, 1, 1, 1), (8192, 1, 1, 1), (16384, 1, 1, 1), (32768, 1, 1, 1), (65536, 1, 1, 1), (131072, 1, 1, 1), (262144, 1, 1, 1), (524288, 1, 1, 1), (1048576, 1, 1, 1), (874, 1, 1, 1), (874, 1, 1, 1), (2097152, 1, 1, 1), (875, 1, 1, 1), (876, 1, 1, 1), (877, 1, 1, 1), (1164, 1, 1, 1), (878, 1, 1, 1), (879, 1, 1, 1), (880, 1, 1, 1), (881, 1, 1, 1), (882, 1, 1, 1), (512, 2, 1, 1), (256, 2, 1, 1), (128, 2, 1, 1), (64, 2, 1, 1), (32, 2, 1, 1), (16, 2, 1, 1), (8, 2, 1, 1), (4, 2, 1, 1), (4, 4, 1, 1), (8, 4, 1, 1), (16, 4, 1, 1), (32, 4, 1, 1), (64, 4, 1, 1), (128, 4, 1, 1), (64, 8, 1, 1), (32, 8, 1, 1), (222, 222, 4, 1), (222, 223, 4, 1), (223, 222, 2, 1), (223, 223, 4, 1), (223, 221, 4, 1), (223, 224, 4, 1), (223, 221, 4, 1), (223, 219, 4, 1), (64, 16, 1, 1), (223, 218, 4, 1), (224, 222, 4, 1)]
+            pos_n = 0
+            for lh_n, lw_n, amp_n, scount in specs_n:
+                rows_n = np.zeros((scount, 600), dtype=np.uint8)
+                for si_n in range(scount):
+                    cnt_n = int(raw_n[pos_n]); pos_n += 1
+                    if cnt_n == 255:
+                        cnt_n = int.from_bytes(raw_n[pos_n:pos_n + 2], "little")
+                        pos_n += 2
+                    idx_n = -1
+                    inds_n = []
+                    for _ in range(cnt_n):
+                        acc_n = 0
+                        sh_n = 0
+                        while True:
+                            by_n = raw_n[pos_n]
+                            pos_n += 1
+                            acc_n |= (by_n & 127) << sh_n
+                            if by_n & 128:
+                                sh_n += 7
+                            else:
+                                break
+                        idx_n += acc_n + 1
+                        inds_n.append(idx_n)
+                    vals_n = np.frombuffer(raw_n, dtype=np.uint8, count=cnt_n, offset=pos_n)
+                    pos_n += cnt_n
+                    if cnt_n:
+                        rows_n[si_n, np.array(inds_n, dtype=np.int64)] = vals_n
+                f1_randmulti_choices.append((torch.from_numpy(rows_n.astype(np.int64)).to(device), lh_n, lw_n, amp_n))
+            if pos_n != len(raw_n):
+                raise ValueError("bad headerless f1 randmulti payload")
+    local_seg_tile_actions = load_seg_tile_actions_data(local_seg_actions_data, device) if local_seg_actions_data is not None else None
+    if local_router_actions_data is not None:
+        local_router_actions_all, local_router_table_id = unpack_router_actions(local_router_actions_data)
+    else:
+        local_router_actions_all = None
+        local_router_table_id = 0
+
+    out_h, out_w = 874, 1164
+    frac_grid_cache = {}
+    frac2_grid_cache = {}
+    frac3_grid_cache = {}
+    randpat_cache = {}
+    cursor = 0
+    pair_cursor = 0
+    batch_size = 4
+
+    # 1 mask per generated pair, assume 600 pairs per standard 1200 frame chunk.
+    pairs_per_file = 600
+
+    with torch.inference_mode():
+        for file_name in files:
+            base_name = os.path.splitext(file_name)[0]
+            raw_out_path = out_dir / f"{base_name}.raw"
+
+            # Retrieve exactly the pairs mapping to this file
+            file_masks = mask_frames_all[cursor : cursor + pairs_per_file]
+            file_poses = pose_frames_all[cursor : cursor + pairs_per_file]
+            cursor += pairs_per_file
+
+            with open(raw_out_path, "wb") as f_out:
+                pbar = tqdm(range(0, file_masks.shape[0], batch_size), desc=f"Decoding {file_name}")
+
+                for i in pbar:
+                    in_mask2 = file_masks[i : i + batch_size].to(device).long()
+                    in_pose6 = file_poses[i : i + batch_size].to(device).float()
+
+                    fake1, fake2 = generator(in_mask2, in_pose6)
+                    if local_seg_tile_actions is not None:
+                        tile_size = 32
+                        grid_w = 512 // tile_size
+                        for batch_j in range(in_mask2.shape[0]):
+                            frame_idx = pair_cursor + i + batch_j
+                            for tile_id, action_id in local_seg_tile_actions["by_frame"].get(frame_idx, []):
+                                y0 = (tile_id // grid_w) * tile_size
+                                x0 = (tile_id % grid_w) * tile_size
+                                fake2[batch_j, :, y0:y0 + tile_size, x0:x0 + tile_size] = (
+                                    fake2[batch_j, :, y0:y0 + tile_size, x0:x0 + tile_size]
+                                    + local_seg_tile_actions["deltas"][action_id]
+                                ).clamp(0, 255)
+
+                    fake1_up = F.interpolate(fake1, size=(out_h, out_w), mode="bilinear", align_corners=False)
+                    fake2_up = F.interpolate(fake2, size=(out_h, out_w), mode="bilinear", align_corners=False)
+
+                    batch_comp = torch.stack([fake1_up, fake2_up], dim=1).clamp(0, 255).round()
+
+                    if postprocess is not None:
+                        batch_hwc = einops.rearrange(batch_comp, "b t c h w -> b t h w c")
+                        b = batch_hwc.shape[0]
+                        for gains, biases, choices in postprocess:
+                            idx = choices[pair_cursor + i : pair_cursor + i + b]
+                            if idx.numel() < b:
+                                idx = F.pad(idx, (0, b - idx.numel()))
+                            idx = idx.clamp(0, gains.shape[0] - 1)
+                            batch_hwc = (batch_hwc * gains[idx] + biases[idx]).clamp(0, 255).round()
+                        if f0_shift_choices is not None:
+                            bsz = batch_hwc.shape[0]
+                            chs = f0_shift_choices[pair_cursor + i : pair_cursor + i + bsz]
+                            for bi in range(bsz):
+                                ch = int(chs[bi].item()) if bi < chs.numel() else 40
+                                if ch != 40:
+                                    dy = ch // 9 - 4
+                                    dx = ch % 9 - 4
+                                    img = batch_hwc[bi, 0].permute(2, 0, 1).unsqueeze(0)
+                                    left, right = max(dx, 0), max(-dx, 0)
+                                    top, bottom = max(dy, 0), max(-dy, 0)
+                                    imgp = F.pad(img, (left, right, top, bottom), mode='replicate')
+                                    y0, x0 = bottom, right
+                                    batch_hwc[bi, 0] = imgp[0, :, y0:y0+out_h, x0:x0+out_w].permute(1, 2, 0)
+                        if f1_frac_choices is not None:
+                            bsz = batch_hwc.shape[0]
+                            chs = f1_frac_choices[pair_cursor + i : pair_cursor + i + bsz]
+                            for bi in range(bsz):
+                                ch = int(chs[bi].item()) if bi < chs.numel() else 4
+                                if ch != 4:
+                                    if ch not in frac_grid_cache:
+                                        dy = (ch // 3 - 1) * 0.5
+                                        dx = (ch % 3 - 1) * 0.5
+                                        yy, xx = torch.meshgrid(torch.arange(out_h, device=device, dtype=torch.float32), torch.arange(out_w, device=device, dtype=torch.float32), indexing='ij')
+                                        gx = ((xx - dx) + 0.5) * 2.0 / out_w - 1.0
+                                        gy = ((yy - dy) + 0.5) * 2.0 / out_h - 1.0
+                                        frac_grid_cache[ch] = torch.stack([gx, gy], dim=-1).unsqueeze(0)
+                                    img = batch_hwc[bi, 0].permute(2, 0, 1).unsqueeze(0).float()
+                                    img = F.grid_sample(img, frac_grid_cache[ch], mode='bilinear', padding_mode='border', align_corners=False)
+                                    batch_hwc[bi, 0] = img[0].clamp(0, 255).round().permute(1, 2, 0)
+                        if f1_frac2_choices is not None:
+                            bsz = batch_hwc.shape[0]
+                            chs = f1_frac2_choices[pair_cursor + i : pair_cursor + i + bsz]
+                            for bi in range(bsz):
+                                ch = int(chs[bi].item()) if bi < chs.numel() else 4
+                                if ch != 4:
+                                    if ch not in frac2_grid_cache:
+                                        dy = (ch // 3 - 1) * 0.25
+                                        dx = (ch % 3 - 1) * 0.25
+                                        yy, xx = torch.meshgrid(torch.arange(out_h, device=device, dtype=torch.float32), torch.arange(out_w, device=device, dtype=torch.float32), indexing='ij')
+                                        gx = ((xx - dx) + 0.5) * 2.0 / out_w - 1.0
+                                        gy = ((yy - dy) + 0.5) * 2.0 / out_h - 1.0
+                                        frac2_grid_cache[ch] = torch.stack([gx, gy], dim=-1).unsqueeze(0)
+                                    img = batch_hwc[bi, 0].permute(2, 0, 1).unsqueeze(0).float()
+                                    img = F.grid_sample(img, frac2_grid_cache[ch], mode='bilinear', padding_mode='border', align_corners=False)
+                                    batch_hwc[bi, 0] = img[0].clamp(0, 255).round().permute(1, 2, 0)
+                        if f1_frac3_choices is not None:
+                            bsz = batch_hwc.shape[0]
+                            chs = f1_frac3_choices[pair_cursor + i : pair_cursor + i + bsz]
+                            for bi in range(bsz):
+                                ch = int(chs[bi].item()) if bi < chs.numel() else 4
+                                if ch != 4:
+                                    if ch not in frac3_grid_cache:
+                                        dy = (ch // 3 - 1) * 0.125
+                                        dx = (ch % 3 - 1) * 0.125
+                                        yy, xx = torch.meshgrid(torch.arange(out_h, device=device, dtype=torch.float32), torch.arange(out_w, device=device, dtype=torch.float32), indexing='ij')
+                                        gx = ((xx - dx) + 0.5) * 2.0 / out_w - 1.0
+                                        gy = ((yy - dy) + 0.5) * 2.0 / out_h - 1.0
+                                        frac3_grid_cache[ch] = torch.stack([gx, gy], dim=-1).unsqueeze(0)
+                                    img = batch_hwc[bi, 0].permute(2, 0, 1).unsqueeze(0).float()
+                                    img = F.grid_sample(img, frac3_grid_cache[ch], mode='bilinear', padding_mode='border', align_corners=False)
+                                    batch_hwc[bi, 0] = img[0].clamp(0, 255).round().permute(1, 2, 0)
+                        if f1_bias_choices is not None:
+                            bsz = batch_hwc.shape[0]
+                            chs = f1_bias_choices[pair_cursor + i : pair_cursor + i + bsz]
+                            for bi in range(bsz):
+                                ch = int(chs[bi].item()) if bi < chs.numel() else 13
+                                if ch != 13:
+                                    br = ch // 9 - 1
+                                    bg = (ch // 3) % 3 - 1
+                                    bb = ch % 3 - 1
+                                    bias = torch.tensor([br, bg, bb], device=device, dtype=batch_hwc.dtype)
+                                    batch_hwc[bi, 0] = (batch_hwc[bi, 0] + bias).clamp(0, 255).round()
+                        if f1_region_choices is not None:
+                            bsz = batch_hwc.shape[0]
+                            chs = f1_region_choices[pair_cursor + i : pair_cursor + i + bsz]
+                            yy_idx = torch.arange(out_h, device=device).view(out_h, 1).expand(out_h, out_w)
+                            xx_idx = torch.arange(out_w, device=device).view(1, out_w).expand(out_h, out_w)
+                            for bi in range(bsz):
+                                ch = int(chs[bi].item()) if bi < chs.numel() else 0
+                                if ch != 0:
+                                    j = ch - 1
+                                    val_list = [-2, -1, 1, 2]
+                                    val = float(val_list[j % 4]); j //= 4
+                                    ci = j % 4; j //= 4
+                                    mi = j
+                                    if mi == 0: mask = (yy_idx < out_h // 2)
+                                    elif mi == 1: mask = (yy_idx >= out_h // 2)
+                                    elif mi == 2: mask = (xx_idx < out_w // 2)
+                                    elif mi == 3: mask = (xx_idx >= out_w // 2)
+                                    elif mi == 4: mask = ((yy_idx >= out_h // 3) & (yy_idx < 2 * out_h // 3))
+                                    else: mask = ((xx_idx >= out_w // 3) & (xx_idx < 2 * out_w // 3))
+                                    if ci == 0:
+                                        batch_hwc[bi, 0][mask, :] = (batch_hwc[bi, 0][mask, :] + val).clamp(0, 255).round()
+                                    else:
+                                        cc = ci - 1
+                                        batch_hwc[bi, 0][mask, cc] = (batch_hwc[bi, 0][mask, cc] + val).clamp(0, 255).round()
+                        if f1_randmulti_choices is not None:
+                            bsz = batch_hwc.shape[0]
+                            for arr_choices, lh_r, lw_r, amp_r in f1_randmulti_choices:
+                                if lh_r == 224 and lw_r == 222 and amp_r == 4:
+                                    # f2 tile bias, 2x2 grid, per-channel radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    yy_idx = torch.arange(out_h, device=device).view(out_h, 1).expand(out_h, out_w)
+                                    xx_idx = torch.arange(out_w, device=device).view(1, out_w).expand(out_h, out_w)
+                                    tile_masks = [
+                                        ((yy_idx < out_h // 2) & (xx_idx < out_w // 2)),
+                                        ((yy_idx < out_h // 2) & (xx_idx >= out_w // 2)),
+                                        ((yy_idx >= out_h // 2) & (xx_idx < out_w // 2)),
+                                        ((yy_idx >= out_h // 2) & (xx_idx >= out_w // 2)),
+                                    ]
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            tile = jj // 24
+                                            rem = jj % 24
+                                            val = vals[rem // 3]
+                                            typ = rem % 3
+                                            if typ == 0:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            mm = tile_masks[tile].unsqueeze(-1)
+                                            batch_hwc[bi, 1] = torch.where(mm, (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 223 and lw_r == 223 and amp_r == 4:
+                                    # f2 boundary all-channel bias, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_low = in_mask2.to(torch.uint8)
+                                    mx = F.max_pool2d(mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    mn = -F.max_pool2d(-mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    bnd_low = (mx != mn).float().unsqueeze(1)
+                                    mask_up = F.interpolate(mask_low.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    bnd = F.interpolate(bnd_low, size=(out_h, out_w), mode="nearest")[:, 0].to(torch.bool)
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            if jj < 8:
+                                                mm = bnd[bi]
+                                                val = vals[jj]
+                                            else:
+                                                jj -= 8
+                                                cls = jj // 8
+                                                val = vals[jj % 8]
+                                                mm = bnd[bi] & (mask_up[bi] == cls)
+                                            bias = torch.tensor([val, val, val], device=device, dtype=batch_hwc.dtype)
+                                            batch_hwc[bi, 1] = torch.where(mm.unsqueeze(-1), (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 223 and lw_r == 222 and amp_r == 2:
+                                    # f2 class-conditioned channel bias, radius 2.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_up = F.interpolate(in_mask2.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    vals = [-2, -1, 1, 2]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            cls = jj // 12
+                                            rem = jj % 12
+                                            val = vals[rem // 3]
+                                            typ = rem % 3
+                                            if typ == 0:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            mm = (mask_up[bi] == cls).unsqueeze(-1)
+                                            batch_hwc[bi, 1] = torch.where(mm, (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 223 and lw_r == 224 and amp_r == 4:
+                                    # f2 boundary/class-boundary channel bias, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_low = in_mask2.to(torch.uint8)
+                                    mx = F.max_pool2d(mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    mn = -F.max_pool2d(-mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    bnd_low = (mx != mn).float().unsqueeze(1)
+                                    mask_up = F.interpolate(mask_low.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    bnd = F.interpolate(bnd_low, size=(out_h, out_w), mode="nearest")[:, 0].to(torch.bool)
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            if jj < 24:
+                                                mm = bnd[bi]
+                                                val = vals[jj // 3]
+                                                typ = jj % 3
+                                            else:
+                                                jj -= 24
+                                                cls = jj // 24
+                                                rem = jj % 24
+                                                val = vals[rem // 3]
+                                                typ = rem % 3
+                                                mm = bnd[bi] & (mask_up[bi] == cls)
+                                            if typ == 0:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            batch_hwc[bi, 1] = torch.where(mm.unsqueeze(-1), (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 223 and lw_r == 219 and amp_r == 4:
+                                    # f2 width-2 boundary channel/class bias, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_low = in_mask2.to(torch.uint8)
+                                    mx = F.max_pool2d(mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    mn = -F.max_pool2d(-mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    bnd_low = (mx != mn).float().unsqueeze(1)
+                                    bnd_low = F.max_pool2d(bnd_low, 3, 1, 1)
+                                    mask_up = F.interpolate(mask_low.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    bnd = F.interpolate(bnd_low, size=(out_h, out_w), mode="nearest")[:, 0].to(torch.bool)
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            if jj < 24:
+                                                mm = bnd[bi]
+                                                val = vals[jj // 3]
+                                                typ = jj % 3
+                                            else:
+                                                jj -= 24
+                                                cls = jj // 24
+                                                rem = jj % 24
+                                                val = vals[rem // 3]
+                                                typ = rem % 3
+                                                mm = bnd[bi] & (mask_up[bi] == cls)
+                                            if typ == 0:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            batch_hwc[bi, 1] = torch.where(mm.unsqueeze(-1), (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 223 and lw_r == 218 and amp_r == 4:
+                                    # f2 width-3 boundary channel/class bias, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_low = in_mask2.to(torch.uint8)
+                                    mx = F.max_pool2d(mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    mn = -F.max_pool2d(-mask_low.float().unsqueeze(1), 3, 1, 1)[:, 0]
+                                    bnd_low = (mx != mn).float().unsqueeze(1)
+                                    bnd_low = F.max_pool2d(bnd_low, 3, 1, 1)
+                                    bnd_low = F.max_pool2d(bnd_low, 3, 1, 1)
+                                    mask_up = F.interpolate(mask_low.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    bnd = F.interpolate(bnd_low, size=(out_h, out_w), mode="nearest")[:, 0].to(torch.bool)
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            if jj < 24:
+                                                mm = bnd[bi]
+                                                val = vals[jj // 3]
+                                                typ = jj % 3
+                                            else:
+                                                jj -= 24
+                                                cls = jj // 24
+                                                rem = jj % 24
+                                                val = vals[rem // 3]
+                                                typ = rem % 3
+                                                mm = bnd[bi] & (mask_up[bi] == cls)
+                                            if typ == 0:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            batch_hwc[bi, 1] = torch.where(mm.unsqueeze(-1), (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 223 and lw_r == 221 and amp_r == 4:
+                                    # f2 class-conditioned channel bias, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_up = F.interpolate(in_mask2.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            cls = jj // 24
+                                            rem = jj % 24
+                                            val = vals[rem // 3]
+                                            typ = rem % 3
+                                            if typ == 0:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            mm = (mask_up[bi] == cls).unsqueeze(-1)
+                                            batch_hwc[bi, 1] = torch.where(mm, (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 223 and lw_r == 221 and amp_r == 4:
+                                    # f2 class-conditioned channel bias, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_up = F.interpolate(in_mask2.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            jj = ch - 1
+                                            cls = jj // 24
+                                            rem = jj % 24
+                                            val = vals[rem // 3]
+                                            typ = rem % 3
+                                            if typ == 0:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            mm = (mask_up[bi] == cls).unsqueeze(-1)
+                                            batch_hwc[bi, 1] = torch.where(mm, (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 222 and lw_r == 223 and amp_r == 4:
+                                    # f2 class-conditioned all-channel bias, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    mask_up = F.interpolate(in_mask2.float().unsqueeze(1), size=(out_h, out_w), mode="nearest")[:, 0].to(torch.uint8)
+                                    vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            cls = (ch - 1) // 8
+                                            val = vals[(ch - 1) % 8]
+                                            mm = (mask_up[bi] == cls).unsqueeze(-1)
+                                            bias = torch.tensor([val, val, val], device=device, dtype=batch_hwc.dtype)
+                                            batch_hwc[bi, 1] = torch.where(mm, (batch_hwc[bi, 1] + bias).clamp(0, 255).round(), batch_hwc[bi, 1])
+                                    continue
+                                if lh_r == 222 and lw_r == 222 and amp_r == 4:
+                                    # f2 global RGB-bias oracle stage, radius 4.
+                                    bsz = batch_hwc.shape[0]
+                                    chs = arr_choices[0, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch != 0:
+                                            vals = [-4, -3, -2, -1, 1, 2, 3, 4]
+                                            val = vals[(ch - 1) // 4]
+                                            typ = (ch - 1) % 4
+                                            if typ == 0:
+                                                bias = torch.tensor([val, val, val], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 1:
+                                                bias = torch.tensor([val, 0, 0], device=device, dtype=batch_hwc.dtype)
+                                            elif typ == 2:
+                                                bias = torch.tensor([0, val, 0], device=device, dtype=batch_hwc.dtype)
+                                            else:
+                                                bias = torch.tensor([0, 0, val], device=device, dtype=batch_hwc.dtype)
+                                            batch_hwc[bi, 1] = (batch_hwc[bi, 1] + bias).clamp(0, 255).round()
+                                    continue
+                                zero_low = None
+                                for st in range(arr_choices.shape[0]):
+                                    chs = arr_choices[st, pair_cursor + i : pair_cursor + i + bsz]
+                                    if chs.numel() < bsz:
+                                        chs = F.pad(chs, (0, bsz - chs.numel()))
+                                    if bool((chs == 0).all().item()):
+                                        continue
+                                    lows = []
+                                    for bi in range(bsz):
+                                        ch = int(chs[bi].item())
+                                        if ch == 0:
+                                            if zero_low is None:
+                                                zero_low = torch.zeros((3, lh_r, lw_r), dtype=torch.float32, device=device)
+                                            lows.append(zero_low)
+                                        else:
+                                            key = (lh_r, lw_r, amp_r, ch)
+                                            if key not in randpat_cache:
+                                                rng = np.random.default_rng(1000 + ch)
+                                                arr = rng.choice(np.array([-1.0, 1.0], dtype=np.float32), size=(3, lh_r, lw_r)).astype(np.float32) * float(amp_r)
+                                                randpat_cache[key] = torch.from_numpy(arr).to(device)
+                                            lows.append(randpat_cache[key])
+                                    pat = F.interpolate(torch.stack(lows, dim=0), size=(out_h, out_w), mode='nearest').permute(0, 2, 3, 1).contiguous()
+                                    batch_hwc[:, 0] = (batch_hwc[:, 0] + pat).clamp(0, 255).round()
+                        batch_comp = einops.rearrange(batch_hwc, "b t h w c -> b t c h w")
+                    if local_router_actions_all is not None:
+                        actions = local_router_actions_all[pair_cursor + i : pair_cursor + i + batch_comp.shape[0]]
+                        batch_comp = apply_router_actions(batch_comp, actions, local_router_table_id)
+
+                    output_bytes = einops.rearrange(batch_comp, "b t c h w -> (b t) h w c").to(torch.uint8)
+                    f_out.write(output_bytes.cpu().numpy().tobytes())
+            pair_cursor += file_masks.shape[0]
+
+if __name__ == "__main__":
+    main()

--- a/submissions/qzs3_range_joint_r258/inflate.sh
+++ b/submissions/qzs3_range_joint_r258/inflate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+ROOT="$HERE"
+while [[ "$ROOT" != "/" && ! -x "$ROOT/.venv/bin/python" ]]; do
+  ROOT="$(dirname "$ROOT")"
+done
+PYTHON="${PYTHON:-}"
+if [[ -z "$PYTHON" ]]; then
+  if [[ -x "$ROOT/.venv/bin/python" ]]; then
+    PYTHON="$ROOT/.venv/bin/python"
+  else
+    PYTHON="$(command -v python3 || command -v python)"
+  fi
+fi
+
+"$PYTHON" "$HERE/inflate.py" "$DATA_DIR" "$OUTPUT_DIR" "$FILE_LIST"

--- a/submissions/qzs3_range_joint_r258/range_mask_codec.cpp
+++ b/submissions/qzs3_range_joint_r258/range_mask_codec.cpp
@@ -1,0 +1,1318 @@
+// Static arithmetic coder audit for exact qpose/Quantizr masks.
+//
+// This is not an inflate-ready submission codec yet. It verifies whether the
+// p6 raster context entropy oracle can be approached by an actual coder.
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr uint8_t SENTINEL = 5;
+constexpr int CTX_COUNT = 216;
+constexpr int CTX5_COUNT = 7776;
+constexpr int CTX6_COUNT = 46656;
+constexpr int CTX7_COUNT = 279936;
+constexpr int CTX8_COUNT = 1679616;
+constexpr int CTX9_COUNT = 10077696;
+constexpr int EVENT_SYMS = 4;
+constexpr int CLASS_SYMS = 5;
+constexpr uint32_t TOP = 0xFFFFFFFFu;
+constexpr uint32_t HALF = 0x80000000u;
+constexpr uint32_t FIRST_QTR = 0x40000000u;
+constexpr uint32_t THIRD_QTR = 0xC0000000u;
+constexpr uint32_t SCALE_TOTAL = 65535;
+
+#ifndef UP_TRUE_INIT
+#define UP_TRUE_INIT 3
+#endif
+#ifndef LEFT_TRUE_INIT
+#define LEFT_TRUE_INIT 4
+#endif
+#ifndef PREV_TRUE_INIT
+#define PREV_TRUE_INIT 3
+#endif
+#ifndef IMPOSSIBLE_FALSE_INIT
+#define IMPOSSIBLE_FALSE_INIT 60000
+#endif
+#ifndef FALLBACK_OTHER_INIT
+#define FALLBACK_OTHER_INIT 3
+#endif
+
+struct Model {
+  std::array<std::array<uint16_t, EVENT_SYMS>, CTX_COUNT> event_freq{};
+  std::array<std::array<uint16_t, CLASS_SYMS>, CTX_COUNT> class_freq{};
+};
+
+struct AdaptiveModel {
+  std::array<std::array<uint16_t, EVENT_SYMS>, CTX5_COUNT> event_freq{};
+  std::array<std::array<uint16_t, CLASS_SYMS>, CTX5_COUNT> class_freq{};
+
+  AdaptiveModel() {
+    for (auto& row : event_freq) row.fill(1);
+    for (auto& row : class_freq) row.fill(1);
+  }
+};
+
+struct AdaptiveModel6 {
+  std::array<std::array<uint16_t, EVENT_SYMS>, CTX6_COUNT> event_freq{};
+  std::array<std::array<uint16_t, CLASS_SYMS>, CTX6_COUNT> class_freq{};
+
+  AdaptiveModel6() {
+    for (auto& row : event_freq) row.fill(1);
+    for (auto& row : class_freq) row.fill(1);
+  }
+};
+
+struct AdaptiveModel7 {
+  std::vector<std::array<uint16_t, EVENT_SYMS>> event_freq;
+  std::vector<std::array<uint16_t, CLASS_SYMS>> class_freq;
+
+  AdaptiveModel7() : event_freq(CTX7_COUNT), class_freq(CTX7_COUNT) {
+    for (auto& row : event_freq) row.fill(1);
+    for (auto& row : class_freq) row.fill(1);
+  }
+};
+
+struct AdaptiveModel8 {
+  std::vector<std::array<uint16_t, EVENT_SYMS>> event_freq;
+  std::vector<std::array<uint16_t, CLASS_SYMS>> class_freq;
+
+  AdaptiveModel8() : event_freq(CTX8_COUNT), class_freq(CTX8_COUNT) {
+    for (auto& row : event_freq) row.fill(1);
+    for (auto& row : class_freq) row.fill(1);
+  }
+};
+
+struct AdaptiveModel9 {
+  std::vector<std::array<uint16_t, EVENT_SYMS>> event_freq;
+  std::vector<std::array<uint16_t, CLASS_SYMS>> class_freq;
+
+  AdaptiveModel9() : event_freq(CTX9_COUNT), class_freq(CTX9_COUNT) {
+    for (auto& row : event_freq) row.fill(1);
+    for (auto& row : class_freq) row.fill(1);
+  }
+};
+
+struct AdaptiveModel9Binary {
+  std::vector<std::array<uint16_t, 2>> prev_freq;
+  std::vector<std::array<uint16_t, 2>> left_freq;
+  std::vector<std::array<uint16_t, 2>> up_freq;
+  std::vector<std::array<uint16_t, CLASS_SYMS>> class_freq;
+
+  AdaptiveModel9Binary()
+      : prev_freq(CTX9_COUNT), left_freq(CTX9_COUNT), up_freq(CTX9_COUNT), class_freq(CTX9_COUNT) {
+    for (int ctx = 0; ctx < CTX9_COUNT; ctx++) {
+      int v = ctx;
+      uint8_t left2 = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t up2 = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t pd = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t pr = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t ur = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t ul = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t up = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t left = static_cast<uint8_t>(v % 6); v /= 6;
+      uint8_t prev = static_cast<uint8_t>(v % 6);
+      (void)left2;
+      (void)up2;
+      (void)pd;
+      (void)pr;
+      (void)ur;
+      (void)ul;
+
+      prev_freq[ctx] = {1, PREV_TRUE_INIT};
+      left_freq[ctx] = {1, LEFT_TRUE_INIT};
+      up_freq[ctx] = {1, UP_TRUE_INIT};
+      class_freq[ctx].fill(1);
+
+      if (up == SENTINEL) up_freq[ctx] = {IMPOSSIBLE_FALSE_INIT, 1};
+      if (left == SENTINEL || left == up) left_freq[ctx] = {IMPOSSIBLE_FALSE_INIT, 1};
+      if (prev == SENTINEL || prev == up || prev == left) prev_freq[ctx] = {IMPOSSIBLE_FALSE_INIT, 1};
+
+      // The fallback class symbol is only reached after up/left/prev have all
+      // been rejected, so valid predictor classes are unlikely in this branch.
+      for (uint8_t cls = 0; cls < CLASS_SYMS; cls++) {
+        if (cls != up && cls != left && cls != prev) class_freq[ctx][cls] = FALLBACK_OTHER_INIT;
+      }
+    }
+  }
+};
+
+struct BitWriter {
+  std::vector<uint8_t> bytes;
+  uint8_t cur = 0;
+  int fill = 0;
+
+  void bit(int b) {
+    cur = static_cast<uint8_t>((cur << 1) | (b & 1));
+    fill++;
+    if (fill == 8) {
+      bytes.push_back(cur);
+      cur = 0;
+      fill = 0;
+    }
+  }
+
+  void finish() {
+    if (fill) {
+      cur <<= (8 - fill);
+      bytes.push_back(cur);
+      cur = 0;
+      fill = 0;
+    }
+  }
+};
+
+struct BitReader {
+  const std::vector<uint8_t>& bytes;
+  size_t pos = 0;
+  int left = 0;
+  uint8_t cur = 0;
+
+  explicit BitReader(const std::vector<uint8_t>& data) : bytes(data) {}
+
+  int bit() {
+    if (left == 0) {
+      cur = pos < bytes.size() ? bytes[pos++] : 0;
+      left = 8;
+    }
+    int b = (cur >> 7) & 1;
+    cur <<= 1;
+    left--;
+    return b;
+  }
+};
+
+struct ArithmeticEncoder {
+  uint32_t low = 0;
+  uint32_t high = TOP;
+  uint32_t pending = 0;
+  BitWriter writer;
+
+  void output_bit_plus_pending(int b) {
+    writer.bit(b);
+    while (pending) {
+      writer.bit(!b);
+      pending--;
+    }
+  }
+
+  void encode(uint32_t cum_low, uint32_t cum_high, uint32_t total) {
+    uint64_t range = static_cast<uint64_t>(high) - low + 1ull;
+    high = static_cast<uint32_t>(low + (range * cum_high) / total - 1ull);
+    low = static_cast<uint32_t>(low + (range * cum_low) / total);
+    while (true) {
+      if (high < HALF) {
+        output_bit_plus_pending(0);
+      } else if (low >= HALF) {
+        output_bit_plus_pending(1);
+        low -= HALF;
+        high -= HALF;
+      } else if (low >= FIRST_QTR && high < THIRD_QTR) {
+        pending++;
+        low -= FIRST_QTR;
+        high -= FIRST_QTR;
+      } else {
+        break;
+      }
+      low <<= 1;
+      high = (high << 1) | 1u;
+    }
+  }
+
+  std::vector<uint8_t> finish() {
+    pending++;
+    if (low < FIRST_QTR) {
+      output_bit_plus_pending(0);
+    } else {
+      output_bit_plus_pending(1);
+    }
+    writer.finish();
+    return std::move(writer.bytes);
+  }
+};
+
+struct ArithmeticDecoder {
+  uint32_t low = 0;
+  uint32_t high = TOP;
+  uint32_t value = 0;
+  BitReader reader;
+
+  explicit ArithmeticDecoder(const std::vector<uint8_t>& data) : reader(data) {
+    for (int i = 0; i < 32; i++) value = (value << 1) | reader.bit();
+  }
+
+  uint32_t scaled(uint32_t total) const {
+    uint64_t range = static_cast<uint64_t>(high) - low + 1ull;
+    return static_cast<uint32_t>((((static_cast<uint64_t>(value) - low + 1ull) * total) - 1ull) / range);
+  }
+
+  void update(uint32_t cum_low, uint32_t cum_high, uint32_t total) {
+    uint64_t range = static_cast<uint64_t>(high) - low + 1ull;
+    high = static_cast<uint32_t>(low + (range * cum_high) / total - 1ull);
+    low = static_cast<uint32_t>(low + (range * cum_low) / total);
+    while (true) {
+      if (high < HALF) {
+        // no-op
+      } else if (low >= HALF) {
+        value -= HALF;
+        low -= HALF;
+        high -= HALF;
+      } else if (low >= FIRST_QTR && high < THIRD_QTR) {
+        value -= FIRST_QTR;
+        low -= FIRST_QTR;
+        high -= FIRST_QTR;
+      } else {
+        break;
+      }
+      low <<= 1;
+      high = (high << 1) | 1u;
+      value = (value << 1) | static_cast<uint32_t>(reader.bit());
+    }
+  }
+};
+
+std::vector<uint8_t> read_file(const std::string& path) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f) throw std::runtime_error("failed to open input: " + path);
+  return std::vector<uint8_t>((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+void write_file(const std::string& path, const std::vector<uint8_t>& data) {
+  std::ofstream f(path, std::ios::binary);
+  if (!f) throw std::runtime_error("failed to open output: " + path);
+  f.write(reinterpret_cast<const char*>(data.data()), static_cast<std::streamsize>(data.size()));
+}
+
+int ctx_id(uint8_t prev, uint8_t left, uint8_t up) {
+  return static_cast<int>(prev) * 36 + static_cast<int>(left) * 6 + static_cast<int>(up);
+}
+
+uint8_t get_prev(const std::vector<uint8_t>& x, size_t frame_size, int t, int y, int w, int xcoord) {
+  if (t == 0) return SENTINEL;
+  return x[static_cast<size_t>(t - 1) * frame_size + static_cast<size_t>(y) * w + xcoord];
+}
+
+uint8_t get_left(const std::vector<uint8_t>& decoded, size_t base, int xcoord) {
+  if (xcoord == 0) return SENTINEL;
+  return decoded[base + static_cast<size_t>(xcoord - 1)];
+}
+
+uint8_t get_up(const std::vector<uint8_t>& decoded, size_t base, int y, int w, int xcoord) {
+  if (y == 0) return SENTINEL;
+  return decoded[base - static_cast<size_t>(w) + xcoord];
+}
+
+uint8_t get_up_left(const std::vector<uint8_t>& decoded, size_t base, int y, int w, int xcoord) {
+  if (y == 0 || xcoord == 0) return SENTINEL;
+  return decoded[base - static_cast<size_t>(w) + xcoord - 1];
+}
+
+uint8_t get_up_right(const std::vector<uint8_t>& decoded, size_t base, int y, int w, int xcoord) {
+  if (y == 0 || xcoord + 1 >= w) return SENTINEL;
+  return decoded[base - static_cast<size_t>(w) + xcoord + 1];
+}
+
+uint8_t get_left2(const std::vector<uint8_t>& decoded, size_t base, int xcoord) {
+  if (xcoord < 2) return SENTINEL;
+  return decoded[base + static_cast<size_t>(xcoord - 2)];
+}
+
+uint8_t get_up2(const std::vector<uint8_t>& decoded, size_t base, int y, int w, int xcoord) {
+  if (y < 2) return SENTINEL;
+  return decoded[base - static_cast<size_t>(2 * w) + xcoord];
+}
+
+uint8_t get_prev_right(const std::vector<uint8_t>& x, size_t frame_size, int t, int y, int w, int xcoord) {
+  if (t == 0 || xcoord + 1 >= w) return SENTINEL;
+  return x[static_cast<size_t>(t - 1) * frame_size + static_cast<size_t>(y) * w + xcoord + 1];
+}
+
+uint8_t get_prev_left(const std::vector<uint8_t>& x, size_t frame_size, int t, int y, int w, int xcoord) {
+  if (t == 0 || xcoord == 0) return SENTINEL;
+  return x[static_cast<size_t>(t - 1) * frame_size + static_cast<size_t>(y) * w + xcoord - 1];
+}
+
+uint8_t get_prev_down(const std::vector<uint8_t>& x, size_t frame_size, int t, int y, int h, int w, int xcoord) {
+  if (t == 0 || y + 1 >= h) return SENTINEL;
+  return x[static_cast<size_t>(t - 1) * frame_size + static_cast<size_t>(y + 1) * w + xcoord];
+}
+
+uint8_t get_prev_up(const std::vector<uint8_t>& x, size_t frame_size, int t, int y, int w, int xcoord) {
+  if (t == 0 || y == 0) return SENTINEL;
+  return x[static_cast<size_t>(t - 1) * frame_size + static_cast<size_t>(y - 1) * w + xcoord];
+}
+
+uint8_t get_prev_down_left(const std::vector<uint8_t>& x, size_t frame_size, int t, int y, int h, int w, int xcoord) {
+  if (t == 0 || y + 1 >= h || xcoord == 0) return SENTINEL;
+  return x[static_cast<size_t>(t - 1) * frame_size + static_cast<size_t>(y + 1) * w + xcoord - 1];
+}
+
+uint8_t get_prev_down_right(const std::vector<uint8_t>& x, size_t frame_size, int t, int y, int h, int w, int xcoord) {
+  if (t == 0 || y + 1 >= h || xcoord + 1 >= w) return SENTINEL;
+  return x[static_cast<size_t>(t - 1) * frame_size + static_cast<size_t>(y + 1) * w + xcoord + 1];
+}
+
+uint8_t event_for(uint8_t cls, uint8_t prev, uint8_t left, uint8_t up) {
+  if (cls == prev) return 0;
+  if (cls == left) return 1;
+  if (cls == up) return 2;
+  return 3;
+}
+
+int ctx5_id(uint8_t prev, uint8_t left, uint8_t up, uint8_t up_left, uint8_t up_right) {
+  return static_cast<int>(prev) * 1296 + static_cast<int>(left) * 216 + static_cast<int>(up) * 36 + static_cast<int>(up_left) * 6 + static_cast<int>(up_right);
+}
+
+int ctx6_id(uint8_t prev, uint8_t left, uint8_t up, uint8_t up_left, uint8_t up_right, uint8_t prev_right) {
+  return static_cast<int>(prev) * 7776 + static_cast<int>(left) * 1296 + static_cast<int>(up) * 216 + static_cast<int>(up_left) * 36 + static_cast<int>(up_right) * 6 + static_cast<int>(prev_right);
+}
+
+int ctx7_id(uint8_t prev, uint8_t left, uint8_t up, uint8_t up_left, uint8_t up_right, uint8_t prev_right, uint8_t prev_down) {
+  return static_cast<int>(prev) * 46656 + static_cast<int>(left) * 7776 + static_cast<int>(up) * 1296 + static_cast<int>(up_left) * 216 + static_cast<int>(up_right) * 36 + static_cast<int>(prev_right) * 6 + static_cast<int>(prev_down);
+}
+
+int ctx8_id(uint8_t prev, uint8_t left, uint8_t up, uint8_t up_left, uint8_t up_right, uint8_t prev_right, uint8_t prev_down, uint8_t prev_left) {
+  return ctx7_id(prev, left, up, up_left, up_right, prev_right, prev_down) * 6 + static_cast<int>(prev_left);
+}
+
+int ctx9_id(uint8_t prev, uint8_t left, uint8_t up, uint8_t up_left, uint8_t up_right, uint8_t prev_right, uint8_t prev_down, uint8_t up2, uint8_t extra) {
+  return ctx8_id(prev, left, up, up_left, up_right, prev_right, prev_down, up2) * 6 + static_cast<int>(extra);
+}
+
+template <size_t N>
+std::array<uint16_t, N> scale_counts(const std::array<uint64_t, N>& counts) {
+  std::array<uint16_t, N> out{};
+  uint64_t total = 0;
+  for (auto c : counts) total += c;
+  if (total == 0) {
+    for (size_t i = 0; i < N; i++) out[i] = 1;
+    return out;
+  }
+  uint32_t used = 0;
+  for (size_t i = 0; i < N; i++) {
+    uint32_t v = std::max<uint32_t>(1, static_cast<uint32_t>((counts[i] * SCALE_TOTAL) / total));
+    out[i] = static_cast<uint16_t>(v);
+    used += v;
+  }
+  while (used > SCALE_TOTAL) {
+    size_t best = 0;
+    for (size_t i = 1; i < N; i++) {
+      if (out[i] > out[best]) best = i;
+    }
+    if (out[best] <= 1) break;
+    out[best]--;
+    used--;
+  }
+  while (used < SCALE_TOTAL) {
+    size_t best = 0;
+    for (size_t i = 1; i < N; i++) {
+      if (counts[i] > counts[best]) best = i;
+    }
+    out[best]++;
+    used++;
+  }
+  return out;
+}
+
+Model build_model(const std::vector<uint8_t>& x, int t_count, int h, int w) {
+  std::array<std::array<uint64_t, EVENT_SYMS>, CTX_COUNT> event_counts{};
+  std::array<std::array<uint64_t, CLASS_SYMS>, CTX_COUNT> class_counts{};
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        int ctx = ctx_id(prev, left, up);
+        uint8_t ev = event_for(cls, prev, left, up);
+        event_counts[ctx][ev]++;
+        if (ev == 3) class_counts[ctx][cls]++;
+        decoded[idx] = cls;
+      }
+    }
+  }
+  Model model;
+  for (int ctx = 0; ctx < CTX_COUNT; ctx++) {
+    model.event_freq[ctx] = scale_counts<EVENT_SYMS>(event_counts[ctx]);
+    model.class_freq[ctx] = scale_counts<CLASS_SYMS>(class_counts[ctx]);
+  }
+  return model;
+}
+
+template <size_t N>
+void encode_symbol(ArithmeticEncoder& enc, const std::array<uint16_t, N>& freq, uint32_t sym) {
+  uint32_t cum = 0;
+  for (uint32_t i = 0; i < sym; i++) cum += freq[i];
+  uint32_t total = 0;
+  for (uint32_t i = 0; i < N; i++) total += freq[i];
+  enc.encode(cum, cum + freq[sym], total);
+}
+
+template <size_t N>
+void update_adaptive(std::array<uint16_t, N>& freq, uint32_t sym) {
+  uint32_t total = 0;
+  for (uint32_t i = 0; i < N; i++) total += freq[i];
+  if (total >= SCALE_TOTAL) {
+    total = 0;
+    for (uint32_t i = 0; i < N; i++) {
+      freq[i] = static_cast<uint16_t>(std::max<uint32_t>(1, (freq[i] + 1) >> 1));
+      total += freq[i];
+    }
+  }
+  (void)total;
+  freq[sym] = static_cast<uint16_t>(
+      std::min<uint32_t>(65535, static_cast<uint32_t>(freq[sym]) + 20));
+}
+
+template <size_t N>
+uint32_t decode_symbol(ArithmeticDecoder& dec, const std::array<uint16_t, N>& freq) {
+  uint32_t total = 0;
+  for (uint32_t i = 0; i < N; i++) total += freq[i];
+  uint32_t v = dec.scaled(total);
+  uint32_t cum = 0;
+  for (uint32_t sym = 0; sym < N; sym++) {
+    uint32_t next = cum + freq[sym];
+    if (v < next) {
+      dec.update(cum, next, total);
+      return sym;
+    }
+    cum = next;
+  }
+  throw std::runtime_error("decode_symbol out of range");
+}
+
+std::vector<uint8_t> encode_payload(const std::vector<uint8_t>& x, int t_count, int h, int w, const Model& model) {
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        int ctx = ctx_id(prev, left, up);
+        uint8_t ev = event_for(cls, prev, left, up);
+        encode_symbol<EVENT_SYMS>(enc, model.event_freq[ctx], ev);
+        if (ev == 3) encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload(const std::vector<uint8_t>& bits, int t_count, int h, int w, const Model& model) {
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        int ctx = ctx_id(prev, left, up);
+        uint8_t ev = static_cast<uint8_t>(decode_symbol<EVENT_SYMS>(dec, model.event_freq[ctx]));
+        uint8_t cls = 0;
+        if (ev == 0) cls = prev;
+        else if (ev == 1) cls = left;
+        else if (ev == 2) cls = up;
+        else cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+std::vector<uint8_t> encode_payload_adaptive5(const std::vector<uint8_t>& x, int t_count, int h, int w) {
+  AdaptiveModel model;
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        uint8_t ul = get_up_left(decoded, base, y, w, xcoord);
+        uint8_t ur = get_up_right(decoded, base, y, w, xcoord);
+        int ctx = ctx5_id(prev, left, up, ul, ur);
+        uint8_t ev = event_for(cls, prev, left, up);
+        encode_symbol<EVENT_SYMS>(enc, model.event_freq[ctx], ev);
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        if (ev == 3) {
+          encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload_adaptive5(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  AdaptiveModel model;
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        uint8_t ul = get_up_left(out, base, y, w, xcoord);
+        uint8_t ur = get_up_right(out, base, y, w, xcoord);
+        int ctx = ctx5_id(prev, left, up, ul, ur);
+        uint8_t ev = static_cast<uint8_t>(decode_symbol<EVENT_SYMS>(dec, model.event_freq[ctx]));
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        uint8_t cls = 0;
+        if (ev == 0) cls = prev;
+        else if (ev == 1) cls = left;
+        else if (ev == 2) cls = up;
+        else {
+          cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+std::vector<uint8_t> encode_payload_adaptive6pr(const std::vector<uint8_t>& x, int t_count, int h, int w) {
+  AdaptiveModel6 model;
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        uint8_t ul = get_up_left(decoded, base, y, w, xcoord);
+        uint8_t ur = get_up_right(decoded, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(x, frame_size, t, y, w, xcoord);
+        int ctx = ctx6_id(prev, left, up, ul, ur, pr);
+        uint8_t ev = event_for(cls, prev, left, up);
+        encode_symbol<EVENT_SYMS>(enc, model.event_freq[ctx], ev);
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        if (ev == 3) {
+          encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload_adaptive6pr(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  AdaptiveModel6 model;
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        uint8_t ul = get_up_left(out, base, y, w, xcoord);
+        uint8_t ur = get_up_right(out, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(out, frame_size, t, y, w, xcoord);
+        int ctx = ctx6_id(prev, left, up, ul, ur, pr);
+        uint8_t ev = static_cast<uint8_t>(decode_symbol<EVENT_SYMS>(dec, model.event_freq[ctx]));
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        uint8_t cls = 0;
+        if (ev == 0) cls = prev;
+        else if (ev == 1) cls = left;
+        else if (ev == 2) cls = up;
+        else {
+          cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+std::vector<uint8_t> encode_payload_adaptive7prpd(const std::vector<uint8_t>& x, int t_count, int h, int w) {
+  AdaptiveModel7 model;
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        uint8_t ul = get_up_left(decoded, base, y, w, xcoord);
+        uint8_t ur = get_up_right(decoded, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(x, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(x, frame_size, t, y, h, w, xcoord);
+        int ctx = ctx7_id(prev, left, up, ul, ur, pr, pd);
+        uint8_t ev = event_for(cls, prev, left, up);
+        encode_symbol<EVENT_SYMS>(enc, model.event_freq[ctx], ev);
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        if (ev == 3) {
+          encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload_adaptive7prpd(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  AdaptiveModel7 model;
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        uint8_t ul = get_up_left(out, base, y, w, xcoord);
+        uint8_t ur = get_up_right(out, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(out, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(out, frame_size, t, y, h, w, xcoord);
+        int ctx = ctx7_id(prev, left, up, ul, ur, pr, pd);
+        uint8_t ev = static_cast<uint8_t>(decode_symbol<EVENT_SYMS>(dec, model.event_freq[ctx]));
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        uint8_t cls = 0;
+        if (ev == 0) cls = prev;
+        else if (ev == 1) cls = left;
+        else if (ev == 2) cls = up;
+        else {
+          cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+std::vector<uint8_t> encode_payload_adaptive8prpdpl(const std::vector<uint8_t>& x, int t_count, int h, int w) {
+  AdaptiveModel8 model;
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        uint8_t ul = get_up_left(decoded, base, y, w, xcoord);
+        uint8_t ur = get_up_right(decoded, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(x, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(x, frame_size, t, y, h, w, xcoord);
+        uint8_t pl = get_prev_left(x, frame_size, t, y, w, xcoord);
+        int ctx = ctx8_id(prev, left, up, ul, ur, pr, pd, pl);
+        uint8_t ev = event_for(cls, prev, left, up);
+        encode_symbol<EVENT_SYMS>(enc, model.event_freq[ctx], ev);
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        if (ev == 3) {
+          encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload_adaptive8prpdpl(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  AdaptiveModel8 model;
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        uint8_t ul = get_up_left(out, base, y, w, xcoord);
+        uint8_t ur = get_up_right(out, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(out, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(out, frame_size, t, y, h, w, xcoord);
+        uint8_t pl = get_prev_left(out, frame_size, t, y, w, xcoord);
+        int ctx = ctx8_id(prev, left, up, ul, ur, pr, pd, pl);
+        uint8_t ev = static_cast<uint8_t>(decode_symbol<EVENT_SYMS>(dec, model.event_freq[ctx]));
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        uint8_t cls = 0;
+        if (ev == 0) cls = prev;
+        else if (ev == 1) cls = left;
+        else if (ev == 2) cls = up;
+        else {
+          cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+uint8_t get_extra8_value(const std::vector<uint8_t>& src, const std::vector<uint8_t>& decoded, size_t frame_size, size_t base, int t, int y, int h, int w, int xcoord, int extra_kind) {
+  switch (extra_kind) {
+    case 0: return get_prev_left(src, frame_size, t, y, w, xcoord);
+    case 1: return get_prev_up(src, frame_size, t, y, w, xcoord);
+    case 2: return get_left2(decoded, base, xcoord);
+    case 3: return get_up2(decoded, base, y, w, xcoord);
+    case 4: return get_prev_down_left(src, frame_size, t, y, h, w, xcoord);
+    case 5: return get_prev_down_right(src, frame_size, t, y, h, w, xcoord);
+    default: return SENTINEL;
+  }
+}
+
+std::vector<uint8_t> encode_payload_adaptive8x(const std::vector<uint8_t>& x, int t_count, int h, int w, int extra_kind) {
+  AdaptiveModel8 model;
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        uint8_t ul = get_up_left(decoded, base, y, w, xcoord);
+        uint8_t ur = get_up_right(decoded, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(x, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(x, frame_size, t, y, h, w, xcoord);
+        uint8_t extra = get_extra8_value(x, decoded, frame_size, base, t, y, h, w, xcoord, extra_kind);
+        int ctx = ctx8_id(prev, left, up, ul, ur, pr, pd, extra);
+        uint8_t ev = event_for(cls, prev, left, up);
+        encode_symbol<EVENT_SYMS>(enc, model.event_freq[ctx], ev);
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        if (ev == 3) {
+          encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload_adaptive8x(const std::vector<uint8_t>& bits, int t_count, int h, int w, int extra_kind) {
+  AdaptiveModel8 model;
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        uint8_t ul = get_up_left(out, base, y, w, xcoord);
+        uint8_t ur = get_up_right(out, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(out, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(out, frame_size, t, y, h, w, xcoord);
+        uint8_t extra = get_extra8_value(out, out, frame_size, base, t, y, h, w, xcoord, extra_kind);
+        int ctx = ctx8_id(prev, left, up, ul, ur, pr, pd, extra);
+        uint8_t ev = static_cast<uint8_t>(decode_symbol<EVENT_SYMS>(dec, model.event_freq[ctx]));
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        uint8_t cls = 0;
+        if (ev == 0) cls = prev;
+        else if (ev == 1) cls = left;
+        else if (ev == 2) cls = up;
+        else {
+          cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+std::vector<uint8_t> encode_payload_adaptive9x(const std::vector<uint8_t>& x, int t_count, int h, int w, int extra_kind) {
+  AdaptiveModel9 model;
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        uint8_t ul = get_up_left(decoded, base, y, w, xcoord);
+        uint8_t ur = get_up_right(decoded, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(x, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(x, frame_size, t, y, h, w, xcoord);
+        uint8_t up2 = get_up2(decoded, base, y, w, xcoord);
+        uint8_t extra = get_extra8_value(x, decoded, frame_size, base, t, y, h, w, xcoord, extra_kind);
+        int ctx = ctx9_id(prev, left, up, ul, ur, pr, pd, up2, extra);
+        uint8_t ev = event_for(cls, prev, left, up);
+        encode_symbol<EVENT_SYMS>(enc, model.event_freq[ctx], ev);
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        if (ev == 3) {
+          encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload_adaptive9x(const std::vector<uint8_t>& bits, int t_count, int h, int w, int extra_kind) {
+  AdaptiveModel9 model;
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        uint8_t ul = get_up_left(out, base, y, w, xcoord);
+        uint8_t ur = get_up_right(out, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(out, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(out, frame_size, t, y, h, w, xcoord);
+        uint8_t up2 = get_up2(out, base, y, w, xcoord);
+        uint8_t extra = get_extra8_value(out, out, frame_size, base, t, y, h, w, xcoord, extra_kind);
+        int ctx = ctx9_id(prev, left, up, ul, ur, pr, pd, up2, extra);
+        uint8_t ev = static_cast<uint8_t>(decode_symbol<EVENT_SYMS>(dec, model.event_freq[ctx]));
+        update_adaptive<EVENT_SYMS>(model.event_freq[ctx], ev);
+        uint8_t cls = 0;
+        if (ev == 0) cls = prev;
+        else if (ev == 1) cls = left;
+        else if (ev == 2) cls = up;
+        else {
+          cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+          update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+        }
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+std::vector<uint8_t> encode_payload_adaptive9bin(const std::vector<uint8_t>& x, int t_count, int h, int w) {
+  AdaptiveModel9Binary model;
+  ArithmeticEncoder enc;
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> decoded(x.size(), 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        size_t idx = base + xcoord;
+        uint8_t cls = x[idx];
+        uint8_t prev = get_prev(x, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(decoded, base, xcoord);
+        uint8_t up = get_up(decoded, base, y, w, xcoord);
+        uint8_t ul = get_up_left(decoded, base, y, w, xcoord);
+        uint8_t ur = get_up_right(decoded, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(x, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(x, frame_size, t, y, h, w, xcoord);
+        uint8_t up2 = get_up2(decoded, base, y, w, xcoord);
+        uint8_t left2 = get_left2(decoded, base, xcoord);
+        int ctx = ctx9_id(prev, left, up, ul, ur, pr, pd, up2, left2);
+        uint8_t b = cls == up;
+        encode_symbol<2>(enc, model.up_freq[ctx], b);
+        update_adaptive<2>(model.up_freq[ctx], b);
+        if (!b) {
+          b = cls == left;
+          encode_symbol<2>(enc, model.left_freq[ctx], b);
+          update_adaptive<2>(model.left_freq[ctx], b);
+          if (!b) {
+            b = cls == prev;
+            encode_symbol<2>(enc, model.prev_freq[ctx], b);
+            update_adaptive<2>(model.prev_freq[ctx], b);
+            if (!b) {
+              encode_symbol<CLASS_SYMS>(enc, model.class_freq[ctx], cls);
+              update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+            }
+          }
+        }
+        decoded[idx] = cls;
+      }
+    }
+  }
+  return enc.finish();
+}
+
+std::vector<uint8_t> decode_payload_adaptive9bin(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  AdaptiveModel9Binary model;
+  ArithmeticDecoder dec(bits);
+  const size_t frame_size = static_cast<size_t>(h) * w;
+  std::vector<uint8_t> out(static_cast<size_t>(t_count) * frame_size, 0);
+  for (int t = 0; t < t_count; t++) {
+    for (int y = 0; y < h; y++) {
+      size_t base = static_cast<size_t>(t) * frame_size + static_cast<size_t>(y) * w;
+      for (int xcoord = 0; xcoord < w; xcoord++) {
+        uint8_t prev = get_prev(out, frame_size, t, y, w, xcoord);
+        uint8_t left = get_left(out, base, xcoord);
+        uint8_t up = get_up(out, base, y, w, xcoord);
+        uint8_t ul = get_up_left(out, base, y, w, xcoord);
+        uint8_t ur = get_up_right(out, base, y, w, xcoord);
+        uint8_t pr = get_prev_right(out, frame_size, t, y, w, xcoord);
+        uint8_t pd = get_prev_down(out, frame_size, t, y, h, w, xcoord);
+        uint8_t up2 = get_up2(out, base, y, w, xcoord);
+        uint8_t left2 = get_left2(out, base, xcoord);
+        int ctx = ctx9_id(prev, left, up, ul, ur, pr, pd, up2, left2);
+        uint8_t cls = 0;
+        uint8_t b = static_cast<uint8_t>(decode_symbol<2>(dec, model.up_freq[ctx]));
+        update_adaptive<2>(model.up_freq[ctx], b);
+        if (b) {
+          cls = up;
+        } else {
+          b = static_cast<uint8_t>(decode_symbol<2>(dec, model.left_freq[ctx]));
+          update_adaptive<2>(model.left_freq[ctx], b);
+          if (b) {
+            cls = left;
+          } else {
+            b = static_cast<uint8_t>(decode_symbol<2>(dec, model.prev_freq[ctx]));
+            update_adaptive<2>(model.prev_freq[ctx], b);
+            if (b) {
+              cls = prev;
+            } else {
+              cls = static_cast<uint8_t>(decode_symbol<CLASS_SYMS>(dec, model.class_freq[ctx]));
+              update_adaptive<CLASS_SYMS>(model.class_freq[ctx], cls);
+            }
+          }
+        }
+        out[base + xcoord] = cls;
+      }
+    }
+  }
+  return out;
+}
+
+void append_u32(std::vector<uint8_t>& out, uint32_t v) {
+  for (int i = 0; i < 4; i++) out.push_back(static_cast<uint8_t>((v >> (i * 8)) & 0xFF));
+}
+
+void append_u16(std::vector<uint8_t>& out, uint16_t v) {
+  out.push_back(static_cast<uint8_t>(v & 0xFF));
+  out.push_back(static_cast<uint8_t>((v >> 8) & 0xFF));
+}
+
+std::vector<uint8_t> serialize(const std::vector<uint8_t>& bits, int t_count, int h, int w, const Model& model) {
+  std::vector<uint8_t> out;
+  out.insert(out.end(), {'Q', 'M', 'R', '1'});
+  append_u32(out, static_cast<uint32_t>(t_count));
+  append_u32(out, static_cast<uint32_t>(h));
+  append_u32(out, static_cast<uint32_t>(w));
+  for (int ctx = 0; ctx < CTX_COUNT; ctx++) {
+    for (auto v : model.event_freq[ctx]) append_u16(out, v);
+    for (auto v : model.class_freq[ctx]) append_u16(out, v);
+  }
+  append_u32(out, static_cast<uint32_t>(bits.size()));
+  out.insert(out.end(), bits.begin(), bits.end());
+  return out;
+}
+
+std::vector<uint8_t> serialize_adaptive(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  std::vector<uint8_t> out;
+  out.insert(out.end(), {'Q', 'M', 'A', '5'});
+  append_u32(out, static_cast<uint32_t>(t_count));
+  append_u32(out, static_cast<uint32_t>(h));
+  append_u32(out, static_cast<uint32_t>(w));
+  append_u32(out, static_cast<uint32_t>(bits.size()));
+  out.insert(out.end(), bits.begin(), bits.end());
+  return out;
+}
+
+std::vector<uint8_t> serialize_adaptive6(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  std::vector<uint8_t> out;
+  out.insert(out.end(), {'Q', 'M', 'A', '6'});
+  append_u32(out, static_cast<uint32_t>(t_count));
+  append_u32(out, static_cast<uint32_t>(h));
+  append_u32(out, static_cast<uint32_t>(w));
+  append_u32(out, static_cast<uint32_t>(bits.size()));
+  out.insert(out.end(), bits.begin(), bits.end());
+  return out;
+}
+
+std::vector<uint8_t> serialize_adaptive7(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  std::vector<uint8_t> out;
+  out.insert(out.end(), {'Q', 'M', 'A', '7'});
+  append_u32(out, static_cast<uint32_t>(t_count));
+  append_u32(out, static_cast<uint32_t>(h));
+  append_u32(out, static_cast<uint32_t>(w));
+  append_u32(out, static_cast<uint32_t>(bits.size()));
+  out.insert(out.end(), bits.begin(), bits.end());
+  return out;
+}
+
+std::vector<uint8_t> serialize_adaptive8(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  std::vector<uint8_t> out;
+  out.insert(out.end(), {'Q', 'M', 'A', '8'});
+  append_u32(out, static_cast<uint32_t>(t_count));
+  append_u32(out, static_cast<uint32_t>(h));
+  append_u32(out, static_cast<uint32_t>(w));
+  append_u32(out, static_cast<uint32_t>(bits.size()));
+  out.insert(out.end(), bits.begin(), bits.end());
+  return out;
+}
+
+std::vector<uint8_t> serialize_adaptive9(const std::vector<uint8_t>& bits, int t_count, int h, int w) {
+  std::vector<uint8_t> out;
+  out.insert(out.end(), {'Q', 'M', 'A', '9'});
+  append_u32(out, static_cast<uint32_t>(t_count));
+  append_u32(out, static_cast<uint32_t>(h));
+  append_u32(out, static_cast<uint32_t>(w));
+  append_u32(out, static_cast<uint32_t>(bits.size()));
+  out.insert(out.end(), bits.begin(), bits.end());
+  return out;
+}
+
+uint32_t read_u32(const std::vector<uint8_t>& data, size_t& off) {
+  if (off + 4 > data.size()) throw std::runtime_error("truncated u32");
+  uint32_t v = static_cast<uint32_t>(data[off]) | (static_cast<uint32_t>(data[off + 1]) << 8) | (static_cast<uint32_t>(data[off + 2]) << 16) | (static_cast<uint32_t>(data[off + 3]) << 24);
+  off += 4;
+  return v;
+}
+
+std::vector<uint8_t> decode_packed_adaptive6(const std::vector<uint8_t>& packed) {
+  if (packed.size() < 20 || packed[0] != 'Q' || packed[1] != 'M' || packed[2] != 'A' || packed[3] != '6') {
+    throw std::runtime_error("not a QMA6 range-mask payload");
+  }
+  size_t off = 4;
+  int t_count = static_cast<int>(read_u32(packed, off));
+  int h = static_cast<int>(read_u32(packed, off));
+  int w = static_cast<int>(read_u32(packed, off));
+  uint32_t bit_bytes = read_u32(packed, off);
+  if (off + bit_bytes > packed.size()) throw std::runtime_error("truncated bitstream");
+  std::vector<uint8_t> bits(packed.begin() + static_cast<std::ptrdiff_t>(off), packed.begin() + static_cast<std::ptrdiff_t>(off + bit_bytes));
+  return decode_payload_adaptive6pr(bits, t_count, h, w);
+}
+
+std::vector<uint8_t> decode_packed_adaptive7(const std::vector<uint8_t>& packed) {
+  if (packed.size() < 20 || packed[0] != 'Q' || packed[1] != 'M' || packed[2] != 'A' || packed[3] != '7') {
+    throw std::runtime_error("not a QMA7 range-mask payload");
+  }
+  size_t off = 4;
+  int t_count = static_cast<int>(read_u32(packed, off));
+  int h = static_cast<int>(read_u32(packed, off));
+  int w = static_cast<int>(read_u32(packed, off));
+  uint32_t bit_bytes = read_u32(packed, off);
+  if (off + bit_bytes > packed.size()) throw std::runtime_error("truncated bitstream");
+  std::vector<uint8_t> bits(packed.begin() + static_cast<std::ptrdiff_t>(off), packed.begin() + static_cast<std::ptrdiff_t>(off + bit_bytes));
+  return decode_payload_adaptive7prpd(bits, t_count, h, w);
+}
+
+std::vector<uint8_t> decode_packed_adaptive8(const std::vector<uint8_t>& packed) {
+  if (packed.size() < 20 || packed[0] != 'Q' || packed[1] != 'M' || packed[2] != 'A' || packed[3] != '8') {
+    throw std::runtime_error("not a QMA8 range-mask payload");
+  }
+  size_t off = 4;
+  int t_count = static_cast<int>(read_u32(packed, off));
+  int h = static_cast<int>(read_u32(packed, off));
+  int w = static_cast<int>(read_u32(packed, off));
+  uint32_t bit_bytes = read_u32(packed, off);
+  if (off + bit_bytes > packed.size()) throw std::runtime_error("truncated bitstream");
+  std::vector<uint8_t> bits(packed.begin() + static_cast<std::ptrdiff_t>(off), packed.begin() + static_cast<std::ptrdiff_t>(off + bit_bytes));
+  // QMA8 submission payloads use the best audit variant:
+  // prev/left/up/up-left/up-right/prev-right/prev-down/current-up2.
+  return decode_payload_adaptive8x(bits, t_count, h, w, 3);
+}
+
+std::vector<uint8_t> decode_packed_adaptive9(const std::vector<uint8_t>& packed) {
+  if (packed.size() < 20 || packed[0] != 'Q' || packed[1] != 'M' || packed[2] != 'A' || packed[3] != '9') {
+    throw std::runtime_error("not a QMA9 range-mask payload");
+  }
+  size_t off = 4;
+  int t_count = static_cast<int>(read_u32(packed, off));
+  int h = static_cast<int>(read_u32(packed, off));
+  int w = static_cast<int>(read_u32(packed, off));
+  uint32_t bit_bytes = read_u32(packed, off);
+  if (off + bit_bytes > packed.size()) throw std::runtime_error("truncated bitstream");
+  std::vector<uint8_t> bits(packed.begin() + static_cast<std::ptrdiff_t>(off), packed.begin() + static_cast<std::ptrdiff_t>(off + bit_bytes));
+  // Best audited QMA9 variant: hierarchical up/left/prev binary decisions
+  // with QMA8 up2 plus current left2 context.
+  return decode_payload_adaptive9bin(bits, t_count, h, w);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc == 4 && std::string(argv[1]) == "decode") {
+    try {
+      std::vector<uint8_t> packed = read_file(argv[2]);
+      std::vector<uint8_t> decoded;
+      if (packed.size() >= 4 && packed[3] == '9') decoded = decode_packed_adaptive9(packed);
+      else if (packed.size() >= 4 && packed[3] == '8') decoded = decode_packed_adaptive8(packed);
+      else if (packed.size() >= 4 && packed[3] == '7') decoded = decode_packed_adaptive7(packed);
+      else decoded = decode_packed_adaptive6(packed);
+      write_file(argv[3], decoded);
+      std::cout << "{\"decoded_bytes\":" << decoded.size() << "}" << std::endl;
+      return 0;
+    } catch (const std::exception& e) {
+      std::cerr << e.what() << "\\n";
+      return 7;
+    }
+  }
+  if (argc != 6 && argc != 7) {
+    std::cerr << "usage: exact_mask_range_codec <raw_u8> <T> <H> <W> <out.bin> [static3|adaptive5|adaptive6pr|adaptive7prpd|adaptive8prpdpl|adaptive8prpdpu|adaptive8prpdleft2|adaptive8prpdup2|adaptive8prpdpdl|adaptive8prpdpdr|adaptive9up2left2|adaptive9up2pu|adaptive9up2pl|adaptive9bin]\\n"
+              << "   or: exact_mask_range_codec decode <in.bin> <out.raw>\\n";
+    return 2;
+  }
+  std::string input_path = argv[1];
+  int t_count = std::stoi(argv[2]);
+  int h = std::stoi(argv[3]);
+  int w = std::stoi(argv[4]);
+  std::string out_path = argv[5];
+  std::string mode = argc == 7 ? argv[6] : "static3";
+  std::vector<uint8_t> x = read_file(input_path);
+  size_t expected = static_cast<size_t>(t_count) * h * w;
+  if (x.size() != expected) {
+    std::cerr << "input size mismatch: got " << x.size() << " expected " << expected << "\\n";
+    return 3;
+  }
+  for (uint8_t v : x) {
+    if (v > 4) {
+      std::cerr << "class value out of range\\n";
+      return 4;
+    }
+  }
+  std::vector<uint8_t> bits;
+  std::vector<uint8_t> decoded;
+  std::vector<uint8_t> packed;
+  if (mode == "static3") {
+    Model model = build_model(x, t_count, h, w);
+    bits = encode_payload(x, t_count, h, w, model);
+    decoded = decode_payload(bits, t_count, h, w, model);
+    packed = serialize(bits, t_count, h, w, model);
+  } else if (mode == "adaptive5") {
+    bits = encode_payload_adaptive5(x, t_count, h, w);
+    decoded = decode_payload_adaptive5(bits, t_count, h, w);
+    packed = serialize_adaptive(bits, t_count, h, w);
+  } else if (mode == "adaptive6pr") {
+    bits = encode_payload_adaptive6pr(x, t_count, h, w);
+    decoded = decode_payload_adaptive6pr(bits, t_count, h, w);
+    packed = serialize_adaptive6(bits, t_count, h, w);
+  } else if (mode == "adaptive7prpd") {
+    bits = encode_payload_adaptive7prpd(x, t_count, h, w);
+    decoded = decode_payload_adaptive7prpd(bits, t_count, h, w);
+    packed = serialize_adaptive7(bits, t_count, h, w);
+  } else if (mode == "adaptive8prpdpl") {
+    bits = encode_payload_adaptive8prpdpl(x, t_count, h, w);
+    decoded = decode_payload_adaptive8prpdpl(bits, t_count, h, w);
+    packed = serialize_adaptive8(bits, t_count, h, w);
+  } else if (mode == "adaptive8prpdpu") {
+    bits = encode_payload_adaptive8x(x, t_count, h, w, 1);
+    decoded = decode_payload_adaptive8x(bits, t_count, h, w, 1);
+    packed = serialize_adaptive8(bits, t_count, h, w);
+  } else if (mode == "adaptive8prpdleft2") {
+    bits = encode_payload_adaptive8x(x, t_count, h, w, 2);
+    decoded = decode_payload_adaptive8x(bits, t_count, h, w, 2);
+    packed = serialize_adaptive8(bits, t_count, h, w);
+  } else if (mode == "adaptive8prpdup2") {
+    bits = encode_payload_adaptive8x(x, t_count, h, w, 3);
+    decoded = decode_payload_adaptive8x(bits, t_count, h, w, 3);
+    packed = serialize_adaptive8(bits, t_count, h, w);
+  } else if (mode == "adaptive8prpdpdl") {
+    bits = encode_payload_adaptive8x(x, t_count, h, w, 4);
+    decoded = decode_payload_adaptive8x(bits, t_count, h, w, 4);
+    packed = serialize_adaptive8(bits, t_count, h, w);
+  } else if (mode == "adaptive8prpdpdr") {
+    bits = encode_payload_adaptive8x(x, t_count, h, w, 5);
+    decoded = decode_payload_adaptive8x(bits, t_count, h, w, 5);
+    packed = serialize_adaptive8(bits, t_count, h, w);
+  } else if (mode == "adaptive9up2left2") {
+    bits = encode_payload_adaptive9x(x, t_count, h, w, 2);
+    decoded = decode_payload_adaptive9x(bits, t_count, h, w, 2);
+    packed = serialize_adaptive9(bits, t_count, h, w);
+  } else if (mode == "adaptive9up2pu") {
+    bits = encode_payload_adaptive9x(x, t_count, h, w, 1);
+    decoded = decode_payload_adaptive9x(bits, t_count, h, w, 1);
+    packed = serialize_adaptive9(bits, t_count, h, w);
+  } else if (mode == "adaptive9up2pl") {
+    bits = encode_payload_adaptive9x(x, t_count, h, w, 0);
+    decoded = decode_payload_adaptive9x(bits, t_count, h, w, 0);
+    packed = serialize_adaptive9(bits, t_count, h, w);
+  } else if (mode == "adaptive9bin") {
+    bits = encode_payload_adaptive9bin(x, t_count, h, w);
+    decoded = decode_payload_adaptive9bin(bits, t_count, h, w);
+    packed = serialize_adaptive9(bits, t_count, h, w);
+  } else {
+    std::cerr << "unknown mode: " << mode << "\\n";
+    return 6;
+  }
+  if (decoded != x) {
+    std::cerr << "decode verification failed\\n";
+    return 5;
+  }
+  write_file(out_path, packed);
+  std::cout << "{"
+            << "\"mode\":\"" << mode << "\","
+            << "\"raw_bytes\":" << x.size() << ","
+            << "\"bitstream_bytes\":" << bits.size() << ","
+            << "\"packed_bytes\":" << packed.size() << ","
+            << "\"model_bytes\":" << (packed.size() - bits.size())
+            << "}" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
# submission name:
qzs3_range_joint_r258

# upload zipped `archive.zip`
https://github.com/nick-neely/comma_video_compression_challenge/releases/download/qzs3-range-joint-r258/archive.zip

SHA256: `f0dedeb7ad3c019ab3f4e2dea317f3192408e47a573897adb208030709d01490`

# report.txt
```
=== Evaluation config ===
  batch_size: 16
  device: cuda
  num_threads: 2
  prefetch_queue_depth: 4
  report: .runs/pr85/pr85_side_search/submission/report.txt
  seed: 1234
  submission_dir: .runs/pr85/pr85_side_search/submission
  uncompressed_dir: /home/neely/dev/comma_video_compression_challenge/videos
  video_names_file: /home/neely/dev/comma_video_compression_challenge/public_test_video_names.txt
=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.00018963
  Average SegNet Distortion: 0.00057675
  Submission file size: 236,516 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.00629945
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 0.26
```

# does your submission require gpu for evaluation (inflation)?
yes

# did you include the compression script? and want it to be merged?
no

# additional comments
Range-coded semantic masks plus a compact joint-frame renderer and small correction stream. Influenced by the adaptive range-mask / joint-frame work in PR #85.
