### PR TITLE
hnerv_lc_v2_scale095_rplus1 submission (0.19538 CPU)

### DIFF
--- a/submissions/hnerv_lc_v2_scale095_rplus1/README.md
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/README.md
@@ -1,0 +1,17 @@
+# hnerv_lc_v2_scale095_rplus1
+
+Built on top of BradyMeighan's `hnerv_lc_v2` PR #100, which itself is built on top of EthanYangTW's `hnerv_muon_finetuned_from_pr95` PR #98 and AaronLeslie138's `hnerv_muon` PR #95.
+
+Changes from PR #100:
+
+- retuned latent correction scale from `0.0100` to `0.0095`;
+- added a zero-byte decode-side nudge: frame 0 red channel `+1`.
+
+Fast PyAV/CUDA scorer result on the public video:
+
+- PoseNet distortion: `0.000033274`
+- SegNet distortion: `0.000575697`
+- archive size: `178,981` bytes
+- exact score: `0.194986956`
+
+The archive payload is unchanged from PR #100; only inference-time code constants changed.

--- a/submissions/hnerv_lc_v2_scale095_rplus1/archive.zip
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/archive.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afd53348f50303bf0ec6a7ffecc1ac037df2f1c70745244b9c45c72e8eb80641
-size 178981

--- a/submissions/hnerv_lc_v2_scale095_rplus1/archive.zip
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/archive.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afd53348f50303bf0ec6a7ffecc1ac037df2f1c70745244b9c45c72e8eb80641
+size 178981

--- a/submissions/hnerv_lc_v2_scale095_rplus1/compress.sh
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/compress.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARCHIVE="${HERE}/archive.zip"
+TMP="${ARCHIVE}.tmp"
+
+URL="https://github.com/BradyMeighan/comma_video_compression_challenge/releases/download/hnerv-lc-v2-archive/archive.zip"
+EXPECTED_SHA256="afd53348f50303bf0ec6a7ffecc1ac037df2f1c70745244b9c45c72e8eb80641"
+
+rm -f "${TMP}"
+
+if command -v curl >/dev/null 2>&1; then
+  curl -L --fail --silent --show-error "${URL}" -o "${TMP}"
+elif command -v python3 >/dev/null 2>&1; then
+  python3 - "${URL}" "${TMP}" <<'PY'
+import sys
+import urllib.request
+
+url, out = sys.argv[1], sys.argv[2]
+with urllib.request.urlopen(url) as r, open(out, "wb") as f:
+    f.write(r.read())
+PY
+else
+  echo "ERROR: need curl or python3 to fetch upstream archive" >&2
+  exit 1
+fi
+
+ACTUAL_SHA256="$(python3 - "${TMP}" <<'PY'
+import hashlib
+import sys
+
+h = hashlib.sha256()
+with open(sys.argv[1], "rb") as f:
+    for chunk in iter(lambda: f.read(1 << 20), b""):
+        h.update(chunk)
+print(h.hexdigest())
+PY
+)"
+
+if [ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]; then
+  echo "ERROR: archive SHA256 mismatch" >&2
+  echo "expected: ${EXPECTED_SHA256}" >&2
+  echo "actual:   ${ACTUAL_SHA256}" >&2
+  rm -f "${TMP}"
+  exit 1
+fi
+
+mv "${TMP}" "${ARCHIVE}"
+echo "wrote ${ARCHIVE}"
+echo "sha256 ${EXPECTED_SHA256}"

--- a/submissions/hnerv_lc_v2_scale095_rplus1/hnerv_model.py
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/hnerv_model.py
@@ -1,0 +1,54 @@
+"""HNeRV-style decoder: 229K params, single-video memorization.
+
+Per-frame-pair latent (28-d) -> 6 upsample stages -> 384x512 RGB pair.
+
+Each stage: Conv(in, out*4, 3x3) + PixelShuffle(2) + bilinear-skip + sin().
+Final: dilated-conv refine residual + sigmoid RGB heads (separate frame 0 and 1).
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class HNeRVDecoder(nn.Module):
+    def __init__(self, latent_dim=28, base_channels=36, eval_size=(384, 512)):
+        super().__init__()
+        self.eval_size = eval_size
+        self.base_h, self.base_w = 6, 8
+        C = base_channels
+
+        # 7 stages from 6x8 to 384x512; channel taper matches HNeRV paper
+        self.channels = [C, C, C, int(C * 0.75), int(C * 0.58), int(C * 0.5), int(C * 0.5)]
+
+        self.stem = nn.Linear(latent_dim, self.channels[0] * self.base_h * self.base_w)
+
+        self.blocks = nn.ModuleList()
+        self.skips = nn.ModuleList()
+        for i in range(6):
+            in_ch = self.channels[i]
+            out_ch = self.channels[i + 1]
+            self.blocks.append(nn.Conv2d(in_ch, out_ch * 4, 3, padding=1))
+            self.skips.append(nn.Conv2d(in_ch, out_ch, 1) if in_ch != out_ch else nn.Identity())
+        self.ps = nn.PixelShuffle(2)
+
+        final_ch = self.channels[-1]
+        self.refine = nn.Sequential(
+            nn.Conv2d(final_ch, final_ch // 2, 3, padding=2, dilation=2),
+            nn.Conv2d(final_ch // 2, final_ch, 3, padding=1),
+        )
+        self.rgb_0 = nn.Conv2d(final_ch, 3, 3, padding=1)
+        self.rgb_1 = nn.Conv2d(final_ch, 3, 3, padding=1)
+
+    def forward(self, z):
+        B = z.shape[0]
+        x = self.stem(z).view(B, self.channels[0], self.base_h, self.base_w)
+        x = torch.sin(x)
+        for block, skip in zip(self.blocks, self.skips):
+            identity = F.interpolate(x, scale_factor=2, mode='bilinear', align_corners=False)
+            identity = skip(identity)
+            x = self.ps(block(x))
+            x = torch.sin(x + identity)
+        x = x + 0.1 * torch.sin(self.refine(x))
+        f0 = torch.sigmoid(self.rgb_0(x)) * 255.0
+        f1 = torch.sigmoid(self.rgb_1(x)) * 255.0
+        return torch.stack([f0, f1], dim=1)

--- a/submissions/hnerv_lc_v2_scale095_rplus1/inflate.py
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/inflate.py
@@ -1,0 +1,130 @@
+"""hnerv_repack_latent inflate: load our compact archive, run AaronLeslie138's HNeRV decoder.
+
+Archive format (single 0.bin file):
+  u32 dec_len   | dec_blob (brotli)   — concatenated INT8 codes (schema-driven)
+  u32 sca_len   | sca_blob            — fp16 scales, one per tensor in schema order
+  u32 lat_len   | lat_blob (brotli)   — per-dim asym uint8 + delta + lo/hi split
+  u32 wrp_len   | wrp_blob (brotli)   — per-pair (u8 dim, i8 quant_delta), dim=255 means no-op
+
+Credits: HNeRV decoder weights and architecture by AaronLeslie138 (PR #95 / hnerv_muon).
+This submission re-packs his archive ~470 B smaller via schema-driven layer names + fp16 scales,
+and adds a ~1.2 KB latent-correction sidecar (per-pair single-dim perturbation chosen to
+minimize SegNet+PoseNet distortion).
+"""
+import io, os, shutil, struct, subprocess, sys, tempfile
+from pathlib import Path
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def _ensure_brotli():
+    try:
+        import brotli  # noqa
+    except ImportError:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'brotli'])
+_ensure_brotli()
+import brotli
+import torch
+import torch.nn.functional as F
+
+from hnerv_model import HNeRVDecoder
+from schema import SCHEMA, META
+from sidecar import decode_corrections, apply_corrections
+
+CAMERA_H, CAMERA_W = 874, 1164
+NATIVE_H, NATIVE_W = META['eval_size']  # (384, 512)
+
+
+def split_archive(b):
+    o = 0
+    parts = []
+    for _ in range(4):
+        L = struct.unpack_from('<I', b, o)[0]; o += 4
+        parts.append(b[o:o+L]); o += L
+    if o != len(b):
+        raise RuntimeError(f'archive trailing: {o} vs {len(b)}')
+    return parts  # [dec, sca, lat, wrp]
+
+
+def decode_decoder(blob, sca_blob):
+    raw = brotli.decompress(blob)
+    codes = np.frombuffer(raw, dtype=np.int8)
+    scales = np.frombuffer(sca_blob, dtype=np.float16)
+    sd = {}
+    o = 0
+    for i, (name, shape) in enumerate(SCHEMA):
+        n_el = int(np.prod(shape))
+        chunk = codes[o:o+n_el].reshape(shape)
+        sd[name] = torch.from_numpy(chunk.astype(np.float32) * float(scales[i]))
+        o += n_el
+    if o != codes.size:
+        raise RuntimeError(f'decoder leftover: {o} vs {codes.size}')
+    return sd
+
+
+def decode_latents(blob):
+    raw = brotli.decompress(blob)
+    buf = io.BytesIO(raw)
+    n, d = struct.unpack('<II', buf.read(8))
+    mins = np.frombuffer(buf.read(d*2), dtype=np.float16).astype(np.float32)
+    scales = np.frombuffer(buf.read(d*2), dtype=np.float16).astype(np.float32)
+    total = n * d
+    lo = np.frombuffer(buf.read(total), dtype=np.uint8).astype(np.uint16)
+    hi = np.frombuffer(buf.read(total), dtype=np.uint8).astype(np.uint16)
+    delta_zz = ((hi << 8) | lo).reshape(n, d)
+    delta = np.where(delta_zz % 2 == 0, delta_zz.astype(np.int32) // 2,
+                     -(delta_zz.astype(np.int32) // 2) - 1).astype(np.int16)
+    q = np.empty_like(delta, dtype=np.int32)
+    q[0] = delta[0]
+    for i in range(1, n):
+        q[i] = q[i-1] + delta[i]
+    return torch.from_numpy(q.astype(np.float32) * scales[None, :] + mins[None, :])
+
+
+def inflate(src_bin: str, dst_raw: str):
+    with open(src_bin, 'rb') as f:
+        archive_bytes = f.read()
+    print(f'[inflate] archive {len(archive_bytes)} bytes', flush=True)
+
+    dec_b, sca_b, lat_b, wrp_b = split_archive(archive_bytes)
+    print(f'[inflate] dec {len(dec_b)} sca {len(sca_b)} lat {len(lat_b)} wrp {len(wrp_b)}', flush=True)
+
+    sd = decode_decoder(dec_b, sca_b)
+    latents = decode_latents(lat_b)
+    if wrp_b:
+        dim_arr, delta_q_arr = decode_corrections(wrp_b)
+        print(f'[inflate] sidecar: {(dim_arr != 255).sum()} pairs with corrections', flush=True)
+        apply_corrections(latents, dim_arr, delta_q_arr)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f'[inflate] device={device}', flush=True)
+    decoder = HNeRVDecoder(latent_dim=META['latent_dim'], base_channels=META['base_channels'], eval_size=tuple(META['eval_size'])).to(device)
+    decoder.load_state_dict(sd)
+    decoder.eval()
+    latents = latents.to(device)
+
+    n_pairs = META['n_pairs']
+    n = 0
+    with torch.inference_mode(), open(dst_raw, 'wb') as fout:
+        for i in range(0, n_pairs, 16):
+            j = min(i + 16, n_pairs)
+            B = j - i
+            decoded = decoder(latents[i:j])  # (B, 2, 3, 384, 512)
+            flat = decoded.reshape(B*2, 3, NATIVE_H, NATIVE_W)
+            up = F.interpolate(flat, size=(CAMERA_H, CAMERA_W), mode='bicubic', align_corners=False)
+            up = up.reshape(B, 2, 3, CAMERA_H, CAMERA_W)
+            up[:, 0, 0].add_(1.0)
+            up = up.reshape(B*2, 3, CAMERA_H, CAMERA_W)
+            frames = (up.clamp(0, 255).permute(0, 2, 3, 1).round().to(torch.uint8).cpu().numpy())
+            fout.write(frames.tobytes())
+            n += B * 2
+    print(f'[inflate] wrote {n} frames to {dst_raw}', flush=True)
+    return n
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("Usage: python -m submissions.hnerv_lc_v2.inflate <src.bin> <dst.raw>")
+    inflate(sys.argv[1], sys.argv[2])

--- a/submissions/hnerv_lc_v2_scale095_rplus1/inflate.sh
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/inflate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+SUB_NAME="$(basename "$HERE")"
+
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Ensure brotli is available (sometimes missing from the eval env)
+python -c "import brotli" 2>/dev/null || pip install --quiet brotli
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  BASE="${line%.*}"
+  SRC="${DATA_DIR}/${BASE}.bin"
+  DST="${OUTPUT_DIR}/${BASE}.raw"
+
+  [ ! -f "$SRC" ] && echo "ERROR: ${SRC} not found" >&2 && exit 1
+
+  printf "Inflating %s ... " "$line"
+  cd "$ROOT"
+  python -m "submissions.${SUB_NAME}.inflate" "$SRC" "$DST"
+done < "$FILE_LIST"

--- a/submissions/hnerv_lc_v2_scale095_rplus1/schema.py
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/schema.py
@@ -1,0 +1,38 @@
+# Auto-generated from AaronLeslie138's hnerv_muon archive.
+META = {
+  'n_pairs': 600,
+  'latent_dim': 28,
+  'base_channels': 36,
+  'eval_size': (384, 512),
+}
+
+SCHEMA = [
+  ('stem.weight', (1728, 28)),
+  ('stem.bias', (1728,)),
+  ('blocks.0.weight', (144, 36, 3, 3)),
+  ('blocks.0.bias', (144,)),
+  ('blocks.1.weight', (144, 36, 3, 3)),
+  ('blocks.1.bias', (144,)),
+  ('blocks.2.weight', (108, 36, 3, 3)),
+  ('blocks.2.bias', (108,)),
+  ('blocks.3.weight', (80, 27, 3, 3)),
+  ('blocks.3.bias', (80,)),
+  ('blocks.4.weight', (72, 20, 3, 3)),
+  ('blocks.4.bias', (72,)),
+  ('blocks.5.weight', (72, 18, 3, 3)),
+  ('blocks.5.bias', (72,)),
+  ('skips.2.weight', (27, 36, 1, 1)),
+  ('skips.2.bias', (27,)),
+  ('skips.3.weight', (20, 27, 1, 1)),
+  ('skips.3.bias', (20,)),
+  ('skips.4.weight', (18, 20, 1, 1)),
+  ('skips.4.bias', (18,)),
+  ('refine.0.weight', (9, 18, 3, 3)),
+  ('refine.0.bias', (9,)),
+  ('refine.1.weight', (18, 9, 3, 3)),
+  ('refine.1.bias', (18,)),
+  ('rgb_0.weight', (3, 18, 3, 3)),
+  ('rgb_0.bias', (3,)),
+  ('rgb_1.weight', (3, 18, 3, 3)),
+  ('rgb_1.bias', (3,)),
+]

--- a/submissions/hnerv_lc_v2_scale095_rplus1/sidecar.py
+++ b/submissions/hnerv_lc_v2_scale095_rplus1/sidecar.py
@@ -1,0 +1,49 @@
+"""Latent-correction sidecar for hnerv_repack_latent.
+
+Wire format (single blob, brotli'd):
+  u16 n_pairs
+  per pair: u8 dim_idx (0..27, or 255 = no correction), i8 delta_quantized (real = i8 * DELTA_SCALE)
+
+At inflate time, for each pair p:
+  if dim_idx[p] != 255:
+      latents[p, dim_idx[p]] += delta_quantized[p] * DELTA_SCALE
+"""
+import struct
+import numpy as np
+
+DELTA_SCALE = 0.0095  # int8 quant: real_delta = i8 * 0.01 (range ±1.27)
+
+
+def encode_corrections(out_dim, out_delta_q):
+    """out_dim, out_delta_q: int8 arrays of length 600. dim=0 + delta_q=0 means 'no correction'.
+    Returns brotli-compressed blob."""
+    import brotli
+    n = len(out_dim)
+    assert len(out_delta_q) == n
+    # Mark 'no correction' as dim=255 (since dim 0 is valid)
+    dim_packed = np.where(out_delta_q == 0, 255, out_dim).astype(np.uint8)
+    payload = struct.pack('<H', n) + np.stack([dim_packed, out_delta_q.astype(np.int8).view(np.uint8)], axis=1).tobytes()
+    return brotli.compress(payload, quality=11)
+
+
+def decode_corrections(blob):
+    """Returns (dim_arr (n, int8), delta_q_arr (n, int8)). dim==255 means no correction."""
+    import brotli
+    raw = brotli.decompress(blob)
+    n = struct.unpack_from('<H', raw, 0)[0]
+    arr = np.frombuffer(raw[2:2 + 2*n], dtype=np.uint8).reshape(n, 2)
+    dim = arr[:, 0]  # uint8 with 255 sentinel
+    delta_q = arr[:, 1].view(np.int8)  # signed
+    return dim, delta_q
+
+
+def apply_corrections(latents_tensor, dim_arr, delta_q_arr, scale=DELTA_SCALE):
+    """In-place add correction to latents_tensor (n, latent_dim). dim==255 means no-op."""
+    import torch
+    n = latents_tensor.shape[0]
+    for p in range(n):
+        d = int(dim_arr[p])
+        if d == 255:
+            continue
+        latents_tensor[p, d] = latents_tensor[p, d] + float(delta_q_arr[p]) * scale
+    return latents_tensor


### PR DESCRIPTION
# submission name:
hnerv_lc_v2_scale095_rplus1

# upload zipped `archive.zip`
Included in this PR under `submissions/hnerv_lc_v2_scale095_rplus1/archive.zip`.

# report.txt
CPU-only run with `CUDA_VISIBLE_DEVICES=''` so inflation also used CPU:
```
=== Evaluation config ===
  batch_size: 16
  device: cpu
  num_threads: 2
  prefetch_queue_depth: 4
  report: submissions/hnerv_lc_v2_scale095_rplus1/report.txt
  seed: 1234
  submission_dir: submissions/hnerv_lc_v2_scale095_rplus1
  uncompressed_dir: /root/comma_video_compression_challenge/videos
  video_names_file: /root/comma_video_compression_challenge/public_test_video_names.txt
=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.00003460
  Average SegNet Distortion: 0.00057602
  Submission file size: 178,981 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.00476704
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 0.20
```
Exact score from rounded CPU report components: `0.1953791765`.

Fast PyAV/CUDA scorer during tuning gave exact `0.194986956` with Pose `0.000033274` and Seg `0.000575697`.

# does your submission require gpu for evaluation (inflation)?
no

# did you include the compression script? and want it to be merged?
yes. `compress.sh` reproduces `archive.zip` by fetching the unchanged PR #100 release archive payload and verifying SHA256. Yes, please merge this submission if accepted.

# additional comments
Built on top of @BradyMeighan's `hnerv_lc_v2` PR #100, which is built on top of @EthanYangTW's `hnerv_muon_finetuned_from_pr95` PR #98 and @AaronLeslie138's `hnerv_muon` PR #95.

Changes from PR #100:
- retuned latent correction scale from `0.0100` to `0.0095`;
- added a zero-byte decode-side nudge: frame 0 red channel `+1`.

The archive payload is unchanged from PR #100; only inference-time code constants changed.
