### PR TITLE
rhnerv_comma submission (0.191)

### DIFF
--- a/submissions/rhnerv_comma/LICENSE
+++ b/submissions/rhnerv_comma/LICENSE
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright (c) 2026 Matt Neel
+Portions copyright (c) their original authors: PR #95 (Aaron Leslie),
+PR #98 (Ethan Yang), PR #101 (SajayR), PR #110 (adpena) — see
+THIRD_PARTY_NOTICES.md for the full lineage.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/submissions/rhnerv_comma/README.md
+++ b/submissions/rhnerv_comma/README.md
@@ -1,0 +1,113 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# rhnerv_comma
+
+Lossless **re-coding of the current #1 payload**. The decoded video is
+byte-identical to PR
+[#110](https://github.com/commaai/comma_video_compression_challenge/pull/110)
+(`hnerv_fec6_fixed_huffman_k16`), whose information content (PR
+[#101](https://github.com/commaai/comma_video_compression_challenge/pull/101)
+decoder weights + latents + sidecar, plus #110's FEC6 selector) is carried in
+1,381 fewer bytes by a context-modeled range coder (`codec_ctx.py`,
+constriction-based): per-tensor adaptive 256-ary models with geometric-primed
+priors for the decoder weight streams, per-dim causal prediction with
+discrete-Gaussian residual models for the latents, and an adaptive 16-ary
+model for the selector. No new training; distortion is unchanged by
+construction.
+
+## Archive identity
+
+| Field | Value |
+|---|---|
+| Score (CPU, full precision) | `0.191126` = 100·seg + sqrt(10·pose) + 25·rate |
+| seg / pose (identical to #110) | `0.00056023` / `0.00002943` |
+| rate | `0.00471790` (177,136 / 37,545,489) |
+| Archive bytes | `177136` (#110: 178,517; saving −1,381 B, −0.000919 score) |
+| Archive SHA-256 | `dd4f3899b91f5b59df90b4bf4fc4d903099a286548339f5f65ff91e4b8146aa4` |
+| ZIP members | 1 (`x`, `compression_type=0` ZIP_STORED, 177,036 bytes) |
+| Member layout | ctx container 176,429 B (7-B header + decoder 161,104 + latents 15,070 + selector 248) ++ verbatim 607-B #101 sidecar (trailing, length-implicit) |
+| Inflate runtime deps | `numpy`, `torch`, `constriction` (all in the harness base env; no `brotli`) |
+| Inflate GPU required | no (device pinned to CPU) |
+| Inflate cost | ~2 m 50 s wall at 4 threads, peak RSS ≈ 2.3 GB (ctx entropy decode itself is < 1 s) |
+
+## What is in the member
+
+The ctx container losslessly re-codes the three entropy-coded sections of the
+#110 member and reproduces, bit-exactly, (a) the 7 raw decoder weight streams
+that #101's Brotli layer carried, (b) the 16,912-byte raw latent payload that
+#101's raw-LZMA1 layer carried, and (c) the 249-byte FEC6 selector wire
+payload of #110. The 607-byte #101 latent-correction sidecar is carried
+verbatim (measured re-coding upside < ~7 B — not worth a format). From those
+bytes to pixels, `inflate.py` runs the **exact** fec6 (#110) chain:
+`HNeRVDecoder` (verbatim PR #95 architecture), 16-pair batches, bicubic
+upsample to 874×1164 (`align_corners=False`), the #98 channel biases
+(frame0 R−1, frame0 B−1, frame1 G−1), `clamp(0,255).round()`, the per-pair
+FEC6 selector transforms (after bias+clamp+round, with a final batch
+`clamp_/round_`), uint8 → NHWC, streamed write.
+
+## Expected output SHA (machine-dependent LSBs)
+
+`F.interpolate(mode='bicubic')` on CPU is bit-stable on a given machine but
+its least-significant bits differ across CPU microarchitectures, so the same
+archive yields different (but locally deterministic) `0.raw` hashes on
+different hosts. Because this submission's decode math is identical to #110's,
+its `0.raw` is byte-identical to #110's **on the same hardware**, whatever the
+hardware:
+
+| Machine | 0.raw SHA-256 |
+|---|---|
+| canonical here (AMD Zen 5, CPU; this repo's `expected_output.sha256`) | `e592c742dfd64fd8d8d42c83ad7066f8c012ed677cbb55644e1e57381106040a` |
+| #110 author's machine (their `expected_output.sha256`) | `d1afc583b01ff4a7aaa844d4f03ece3ed381d56763a06cb2c5e011526e5f868c` |
+
+Both machines reproduce the official #110 CI metrics to all 8 printed
+decimals (seg `0.00056023`, pose `0.00002943`), so the metric gate is
+hash-independent.
+
+## Quick reproducibility check (≈60 s setup + ~3 min inflate, CPU only)
+
+```bash
+# 1) rebuild archive.zip from the pinned upstream releases (SHA-256-verified;
+#    deterministic: IEEE-exact float64 model construction on any platform)
+bash compress.sh           # or: --pr101 <local>/archive.zip --pr110 <local>/archive.zip
+sha256sum archive.zip
+# expect: dd4f3899b91f5b59df90b4bf4fc4d903099a286548339f5f65ff91e4b8146aa4  (177,136 B)
+
+# 2) inflate against this submission dir on CPU
+mkdir -p /tmp/data /tmp/out
+unzip -oq archive.zip -d /tmp/data
+echo "0.mkv" > /tmp/list.txt
+bash inflate.sh /tmp/data /tmp/out /tmp/list.txt
+
+# 3) verify byte-stable decode against the canonical SHA for this machine
+sha256sum /tmp/out/0.raw   # see expected_output.sha256 + table above
+```
+
+Or run the full harness from the challenge repo:
+
+```bash
+uv run --no-sync --group cpu bash evaluate.sh --device cpu --submission-dir <this dir>
+```
+
+## Files
+
+| Path | Role |
+|---|---|
+| `compress.sh`, `compress.py` | Encoder: curl + SHA-check the pinned #101/#110 archives, entropy-decode their payloads to raw bytes, re-code with the ctx coder, byte-exact round-trip assert, deterministic zip. |
+| `inflate.sh`, `inflate.py` | Contest-runtime decoder (accepts member `x` or `<base>.bin`). |
+| `codec_ctx.py` | Context-modeled range coder (encoder + decoder; the new code). |
+| `codec.py` | #101 tensor reconstruction, ported from fec6 to take raw stream bytes (entropy layer swapped, math verbatim). |
+| `codec_sidecar.py` | #101 607-B enum-rank sidecar decode (verbatim fec6 bodies, other formats dropped). |
+| `frame_selector.py` | Verbatim fec6 module (blue-chroma tile + transform families). |
+| `model.py` | Verbatim fec6 copy of the PR #95 HNeRV decoder. |
+| `expected_output.sha256` | Canonical CPU decode SHA on this machine (see table above). |
+| `THIRD_PARTY_NOTICES.md` | Upstream attribution (PR #95 / #98 / #101 / #110). |
+
+## Reproduction recipe
+
+Inputs (not redistributed; fetched + SHA-256-pinned by `compress.sh`):
+PR #101 `archive.zip` (`b83bf348…`) and PR #110 `archive.zip` (`6bae0201…`)
+from their respective releases. `compress.py` cross-checks that #110 embeds
+#101's source payload byte-for-byte before extracting the selector. The
+encoder is deterministic and runs in seconds; the decode-side model
+construction uses only IEEE-exact float64 multiply/add/divide, so encoder and
+decoder build bit-identical probability tables on any IEEE-754 platform.

--- a/submissions/rhnerv_comma/THIRD_PARTY_NOTICES.md
+++ b/submissions/rhnerv_comma/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,90 @@
+# Third-Party Notices
+
+This submission inherits from prior work in the contest repository. All
+upstream code is reused under the contest repository's MIT license. This
+document acknowledges the upstream contributions and identifies the
+corresponding files in this submission.
+
+The submission is a **lossless re-coding**: every bit of video-specific
+information in its `archive.zip` originates in PR #101 and PR #110; only the
+entropy-coding layer that carries that information is new.
+
+## PR #95 — HNeRV decoder
+
+- **Author**: @AaronLeslie138
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/95
+- **License**: MIT (inherited from the contest repository)
+- **What this submission uses**: the HNeRV-style decoder architecture (229K
+  parameters, per-frame-pair latent → 6 upsample stages → 384×512 RGB pair).
+  `model.py` is a verbatim copy of the fec6 (#110) copy, which is
+  byte-identical to PR #95's implementation. No new training was performed.
+
+## PR #98 — finetuned weights + channel-bias inflate
+
+- **Author**: @EthanYangTW
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/98
+- **License**: MIT (inherited from the contest repository)
+- **What this submission uses**: the decoder weights and latents that #101
+  packs are byte-identical to #98's finetune of the #95 weights, and the
+  per-pair channel-bias step in `inflate.py` (frame0 R−1, frame0 B−1,
+  frame1 G−1, applied before clamp/round) originates in #98's inflate.
+
+## PR #101 — `hnerv_ft_microcodec` payload content
+
+- **Author**: @SajayR
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/101
+- **License**: MIT (inherited from the contest repository)
+- **What this submission uses**: the decoder weights, latent codes, and the
+  607-byte latent-correction sidecar — i.e. the entire model content of this
+  archive — are PR #101's, reused **information-identically**: the weight
+  streams and latent payload are re-coded losslessly by the ctx coder (their
+  raw bytes are reproduced bit-exactly at inflate time), and the sidecar is
+  carried verbatim. The tensor-reconstruction grammar in `codec.py` and the
+  sidecar decode in `codec_sidecar.py` are ports of PR #101's decode logic as
+  published in-tree by PR #110. The offline encoder (`compress.sh`) fetches
+  PR #101's archive from its release (SHA-256:
+  `b83bf3488625dbd73adeddff91712994197ab53098e578e91327a0c6e49efb3e`) and
+  never redistributes it.
+
+## PR #110 — `hnerv_fec6_fixed_huffman_k16` selector + inflate chain
+
+- **Author**: @adpena
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/110
+- **License**: MIT (sole-author Alejandro Peña, per its in-tree LICENSE)
+- **What this submission uses**: the FEC6 K=16 per-pair selector **content**
+  (its 249-byte wire payload is regenerated bit-exactly by the ctx selector
+  section) and the complete inflate transform chain — batching, bicubic
+  upsample, clamp/round ordering, and the per-pair selector application order
+  (transforms after bias+clamp+round, then a final batch clamp/round).
+  `inflate.py` is derived from fec6's `inflate.py` (FEC6 mode table, Huffman
+  decode, and transform-apply functions verbatim; container parsing replaced,
+  device pinned to CPU); `frame_selector.py` is a verbatim copy; `codec.py`
+  and `codec_sidecar.py` keep fec6's function bodies verbatim with the
+  entropy layer swapped (raw bytes in, no Brotli/LZMA). The offline encoder
+  fetches PR #110's archive from its release (SHA-256:
+  `6bae0201fb082457a02c69565531aba4c5942669c384fdc48e7d554f7b893fcf`) and
+  never redistributes it.
+
+## Open-source dependencies
+
+- **constriction** (https://github.com/bamler-lab/constriction, MIT/Apache-2.0
+  /BSL) — range coding primitives used by the ctx coder at both encode and
+  inflate time.
+- **Brotli** (RFC 7932; `brotli` PyPI package, MIT) — used at **encode time
+  only**, to unwrap PR #101's source streams before re-coding. The inflate
+  path of this submission does not use Brotli.
+- **raw LZMA1** (`lzma` stdlib) — used at encode time only, to unwrap PR
+  #101's latent payload before re-coding.
+
+## This submission's contributions
+
+- `codec_ctx.py` — context-modeled range coder for the three payload
+  sections (adaptive geometric-primed weight models, causal-prediction latent
+  models with discrete-Gaussian residuals, adaptive selector model), with
+  platform-independent decode-side model construction. New code.
+- `compress.py` / `compress.sh` — pinned-input encoder driver with byte-exact
+  round-trip verification and deterministic packaging. New code.
+- `inflate.py` — composes the ctx container decode with PR #101's tensor
+  reconstruction and PR #110's transform chain.
+
+All new code is MIT-licensed under the same terms as the contest repository.

--- a/submissions/rhnerv_comma/codec.py
+++ b/submissions/rhnerv_comma/codec.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MIT
+"""Inflater-side codec for the PR #101 HNeRV-microcodec payload, raw-stream
+variant.
+
+Ported from `submissions/hnerv_fec6_fixed_huffman_k16/src/codec.py` (PR #110,
+@adpena, MIT), which itself reuses PR #101's (@SajayR) decode grammar. The
+ONLY functional change vs the fec6 original: the entropy-coding layer has been
+swapped out. `decode_decoder_compact` takes the RAW concatenated decoder
+stream bytes directly (already entropy-decoded by `codec_ctx`) instead of a
+Brotli blob, and `decode_latents_compact` takes the raw latent payload
+directly instead of an LZMA blob. Everything downstream of the entropy layer
+-- storage order, conv4 storage permutations, byte maps, scale handling,
+latent delta/cumsum reconstruction, dim reordering, fp32 math -- is verbatim
+fec6/#101, so the reconstructed tensors are bit-identical.
+
+All schema constants live in code (uncounted by the rate metric); the
+archive carries only video-specific payload bytes.
+"""
+import io
+
+import numpy as np
+import torch
+
+from model import HNeRVDecoder
+
+
+N_PAIRS = 600
+LATENT_DIM = 28
+BASE_CHANNELS = 36
+EVAL_SIZE = (384, 512)
+DECODER_RAW_LEN = 229_014   # sum of the 7 raw decoder streams
+LATENT_RAW_LEN = 16_912     # 2*2*28 fp16 header + 600*28 codes
+
+DECODER_STORAGE_ORDER = (
+    14, 22, 7, 6, 19, 10, 25, 4, 20, 9, 12, 15, 5, 11,
+    18, 1, 21, 3, 27, 13, 2, 26, 24, 17, 16, 23, 8, 0,
+)
+DECODER_STREAM_ENDS = (1, 2, 22, 23, 26, 27, 28)
+
+CONV4_STORAGE_PERMS = {
+    2: (3, 0, 2, 1),
+    4: (3, 0, 2, 1),
+    6: (0, 1, 2, 3),
+    8: (3, 0, 1, 2),
+    10: (3, 0, 2, 1),
+    12: (3, 0, 1, 2),
+    14: (1, 0, 2, 3),
+    16: (3, 0, 2, 1),
+    18: (1, 0, 2, 3),
+    20: (0, 3, 2, 1),
+    22: (0, 3, 2, 1),
+    24: (0, 2, 3, 1),
+    26: (0, 1, 3, 2),
+}
+CONV4_INVERSE_PERMS = {
+    idx: tuple(np.argsort(perm)) for idx, perm in CONV4_STORAGE_PERMS.items()
+}
+
+DECODER_BYTE_MAPS = {
+    9: "negzig",
+    14: "negzig",
+    20: "twos",
+    27: "off",
+}
+
+LATENT_DIM_ORDER = (
+    26, 0, 17, 15, 10, 24, 20, 12, 14, 21, 22, 18, 4, 11,
+    3, 7, 16, 2, 6, 8, 19, 23, 5, 9, 1, 13, 27, 25,
+)
+
+
+def zigzag_decode_u8(arr_u8):
+    """Map unsigned zigzag symbols back to signed int8 residuals."""
+    arr = arr_u8.astype(np.int32)
+    return np.where(arr % 2 == 0, arr // 2, -(arr // 2) - 1).astype(np.int8)
+
+
+def decode_mapped_u8(arr_u8, byte_map):
+    """Decode one stored uint8 tensor stream using its declared byte map."""
+    if byte_map == "zig":
+        return zigzag_decode_u8(arr_u8)
+    if byte_map == "negzig":
+        return (-zigzag_decode_u8(arr_u8).astype(np.int16)).astype(np.int8)
+    if byte_map == "off":
+        return (arr_u8.astype(np.int16) - 128).astype(np.int8)
+    if byte_map == "twos":
+        return arr_u8.view(np.int8)
+    raise ValueError(f"unknown decoder byte map: {byte_map}")
+
+
+def decode_decoder_compact(raw):
+    """Decode the compact HNeRV state_dict from RAW concatenated stream bytes.
+
+    `raw` is the byte concatenation of the 7 decoder streams that
+    `codec_ctx.unpack_container` returns (per-tensor q-bytes + fp16 scale, in
+    DECODER_STORAGE_ORDER). Identical to fec6's decode_decoder_compact after
+    its Brotli step."""
+    if len(raw) != DECODER_RAW_LEN:
+        raise ValueError("bad raw decoder stream length")
+    probe = HNeRVDecoder(
+        latent_dim=LATENT_DIM,
+        base_channels=BASE_CHANNELS,
+        eval_size=EVAL_SIZE,
+    )
+    items = list(probe.state_dict().items())
+    pos = 0
+    sd = {}
+
+    for idx in DECODER_STORAGE_ORDER:
+        name, tensor = items[idx]
+        shape = tuple(tensor.shape)
+        numel = int(tensor.numel())
+        zz = np.frombuffer(raw, dtype=np.uint8, count=numel, offset=pos)
+        pos += numel
+        scale = np.frombuffer(raw, dtype=np.float16, count=1, offset=pos)[0]
+        pos += 2
+
+        q = decode_mapped_u8(zz, DECODER_BYTE_MAPS.get(idx, "zig"))
+        if len(shape) == 4:
+            storage_perm = CONV4_STORAGE_PERMS[idx]
+            inverse_perm = CONV4_INVERSE_PERMS[idx]
+            stored_shape = tuple(shape[i] for i in storage_perm)
+            q = q.reshape(stored_shape)
+            q = np.transpose(q, inverse_perm).copy()
+        else:
+            q = q.reshape(shape)
+        sd[name] = torch.from_numpy(q.astype(np.float32)) * float(scale)
+
+    if pos != len(raw):
+        raise ValueError("trailing or truncated compact decoder payload")
+    return sd
+
+
+def decode_latents_compact(raw):
+    """Decode RAW per-pair latent payload bytes into float tensors.
+
+    `raw` is what fec6's decode_latents_compact sees after its LZMA step:
+    fp16 mins + fp16 scales + centered temporal-delta uint8 codes."""
+    if len(raw) != LATENT_RAW_LEN:
+        raise ValueError("bad raw latent payload length")
+    buf = io.BytesIO(raw)
+    mins = torch.from_numpy(
+        np.frombuffer(buf.read(LATENT_DIM * 2), dtype=np.float16).copy()
+    ).float()
+    scales = torch.from_numpy(
+        np.frombuffer(buf.read(LATENT_DIM * 2), dtype=np.float16).copy()
+    ).float()
+    stored = np.frombuffer(buf.read(N_PAIRS * LATENT_DIM), dtype=np.uint8)
+    if stored.size != N_PAIRS * LATENT_DIM:
+        raise ValueError("truncated compact latent payload")
+    delta_ordered = stored.reshape(LATENT_DIM, N_PAIRS)
+    q_ordered = delta_ordered.copy()
+    q_ordered[:, 1:] = np.cumsum(
+        ((delta_ordered[:, 1:].astype(np.int16) - 128) & 255),
+        axis=1,
+        dtype=np.uint16,
+    ).astype(np.uint8) + delta_ordered[:, :1]
+    q_ordered = q_ordered.T.copy()
+    q = np.empty((N_PAIRS, LATENT_DIM), dtype=np.uint8)
+    q[:, LATENT_DIM_ORDER] = q_ordered
+    return torch.from_numpy(q.astype(np.float32)) * scales.unsqueeze(0) + mins.unsqueeze(0)

--- a/submissions/rhnerv_comma/codec_ctx.py
+++ b/submissions/rhnerv_comma/codec_ctx.py
@@ -1,0 +1,695 @@
+# SPDX-License-Identifier: MIT
+"""Context-modeled entropy coder for the #101/#110 payload sections.
+
+Replaces the off-the-shelf coders of the current #1 submission payload with
+constriction-based adaptive/parametric range coding:
+
+  decoder weights : one range stream; per-tensor adaptive 256-ary models with
+                    geometric-primed prior counts. Prior decay rho, prior
+                    strength M, floor eps, and adaptation increment are chosen
+                    per model by exact simulated code length and transmitted
+                    in a 2-byte/model header. fp16 scale low bytes are stored
+                    raw; the (highly redundant) high bytes are entropy-coded.
+  latents         : per-dim causal prediction (AR(1) on own quantized deltas,
+                    optional own-lag-2 and up to 4 already-decoded dims at the
+                    same time step; integer-quantized LS coefficients) with
+                    static discrete-Gaussian residual models (u16 parameter
+                    per dim) or, where the encoder measures a win, an
+                    adaptive Gaussian-primed model. fp16 min/scale high bytes
+                    entropy-coded like the decoder scales.
+  selector        : adaptive 16-ary model over the FEC6 mode indices
+                    (recovers the exact 249-byte FEC6 wrapper on decode).
+
+All decode-side model construction uses only IEEE-exact float64 operations
+(multiply / add / divide), so encoder and decoder build bit-identical
+probability tables on any IEEE-754 platform. Decode-side deps: numpy +
+constriction (harness base deps) (+ brotli/lzma stdlib for passthrough).
+
+Container (member produced by `pack_container`):
+  u8 version | u8 coder-id bitmap (2 bits/section: decoder, latent, selector)
+  | u24 len(decoder section) | u24 len(latent section) | selector section.
+Coder id 0 = passthrough (current bytes verbatim), 1 = this coder.
+"""
+from __future__ import annotations
+
+import math
+import struct
+
+import numpy as np
+
+try:
+    import constriction
+except ImportError:  # schema constants remain importable without it
+    constriction = None
+
+VERSION = 1
+CODER_PASSTHROUGH = 0
+CODER_CTX = 1
+
+# ---------------------------------------------------------------------------
+# fixed schema of the #101 decoder payload (verified against
+# submissions/hnerv_fec6_fixed_huffman_k16/src/codec.py and the archive)
+# ---------------------------------------------------------------------------
+# (tensor_idx, numel) per storage position; streams split per STREAM_ENDS.
+TENSOR_SCHEMA = (
+    (14, 972), (22, 1458), (7, 108), (6, 34992), (19, 18), (10, 12960),
+    (25, 3), (4, 46656), (20, 1458), (9, 80), (12, 11664), (15, 27),
+    (5, 144), (11, 72), (18, 360), (1, 1728), (21, 9), (3, 144), (27, 3),
+    (13, 72), (2, 46656), (26, 486), (24, 486), (17, 20), (16, 540),
+    (23, 18), (8, 19440), (0, 48384),
+)
+STREAM_ENDS = (1, 2, 22, 23, 26, 27, 28)
+N_STREAMS = len(STREAM_ENDS)
+N_TENSORS = len(TENSOR_SCHEMA)
+# byte maps that need a magnitude-ordering remap for the geometric prior
+TWOS_TENSORS = frozenset({20})
+OFF_TENSORS = frozenset({27})
+# tensors sharing one adaptive model (chosen by exact cost on the encoder;
+# fixed here so the decoder needs no signalling)
+SHARED_MODEL_TENSORS = frozenset({7, 5, 1, 3})
+
+M_GRID = (4.0, 16.0, 64.0, 256.0, 1024.0)          # 3 bits
+INC_GRID = (1.0, 1.5, 2.0, 3.0)                    # 2 bits
+EPS_GRID = (0.01, 0.05, 0.15, 0.4)                 # 2 bits
+
+N_PAIRS = 600
+LATENT_DIM = 28
+LATENT_HDR = 112  # fp16 mins + scales
+LATENT_ADAPT_M = 480.0
+SELECTOR_MAGIC = b"FEC6"
+FEC6_CODE_BITS = (
+    "00", "1100", "01", "111010", "11010", "111011", "111100", "100",
+    "111101", "11011", "1111110", "111110", "11111110", "101", "11100",
+    "11111111",
+)
+LAG2_SRC = 255  # spec marker: feature is own lag-2 instead of a cross dim
+
+# discrete-Gaussian parameter grid: Q_TABLE[k] = round(65535*exp(-1/(2*s^2)))
+# for s = 0.3*(80/0.3)^(k/255) -- precomputed so the decoder never calls exp().
+Q_TABLE = (
+    253, 321, 404, 502, 619, 756, 915, 1099, 1309, 1549,
+    1818, 2120, 2456, 2827, 3235, 3681, 4164, 4686, 5247, 5847,
+    6485, 7161, 7874, 8623, 9406, 10222, 11070, 11947, 12851, 13780,
+    14733, 15706, 16698, 17706, 18728, 19761, 20803, 21852, 22905, 23961,
+    25017, 26071, 27122, 28167, 29206, 30235, 31255, 32263, 33258, 34239,
+    35205, 36155, 37089, 38005, 38903, 39783, 40643, 41484, 42305, 43106,
+    43888, 44648, 45389, 46109, 46809, 47489, 48150, 48790, 49411, 50013,
+    50596, 51160, 51706, 52234, 52744, 53238, 53714, 54174, 54618, 55046,
+    55459, 55858, 56241, 56611, 56968, 57311, 57641, 57959, 58265, 58560,
+    58843, 59115, 59377, 59629, 59871, 60103, 60326, 60541, 60747, 60945,
+    61135, 61317, 61492, 61660, 61822, 61976, 62125, 62267, 62404, 62535,
+    62661, 62781, 62897, 63008, 63114, 63216, 63314, 63407, 63497, 63583,
+    63666, 63745, 63820, 63893, 63963, 64029, 64093, 64154, 64213, 64269,
+    64323, 64374, 64424, 64471, 64516, 64559, 64601, 64641, 64679, 64715,
+    64750, 64784, 64816, 64846, 64876, 64904, 64931, 64957, 64981, 65005,
+    65028, 65049, 65070, 65090, 65109, 65127, 65144, 65161, 65177, 65192,
+    65207, 65221, 65235, 65247, 65260, 65271, 65283, 65294, 65304, 65314,
+    65323, 65332, 65341, 65349, 65357, 65365, 65372, 65379, 65386, 65392,
+    65398, 65404, 65410, 65415, 65420, 65425, 65430, 65434, 65439, 65443,
+    65447, 65451, 65454, 65458, 65461, 65464, 65467, 65470, 65473, 65475,
+    65478, 65480, 65483, 65485, 65487, 65489, 65491, 65493, 65495, 65497,
+    65498, 65500, 65501, 65503, 65504, 65505, 65507, 65508, 65509, 65510,
+    65511, 65512, 65513, 65514, 65515, 65516, 65517, 65518, 65518, 65519,
+    65520, 65520, 65521, 65522, 65522, 65523, 65523, 65524, 65524, 65525,
+    65525, 65526, 65526, 65526, 65527, 65527, 65527, 65528, 65528, 65528,
+    65529, 65529, 65529, 65529, 65530, 65530,
+)
+
+
+# ---------------------------------------------------------------------------
+# deterministic model construction helpers
+# ---------------------------------------------------------------------------
+def _geometric_pmf(rho_q: int) -> np.ndarray:
+    """pmf[k] = (1-r) * r^k built by repeated IEEE multiplication."""
+    r = rho_q / 255.0
+    out = np.empty(256, np.float64)
+    v = 1.0 - r
+    for k in range(256):
+        out[k] = v
+        v = v * r
+    return out
+
+
+def _remap_table(tensor_idx: int) -> np.ndarray:
+    """Map stored byte -> magnitude-ordered index used by the prior."""
+    v = np.arange(256, dtype=np.int64)
+    if tensor_idx in TWOS_TENSORS:
+        x = np.where(v >= 128, v - 256, v)
+    elif tensor_idx in OFF_TENSORS:
+        x = v - 128
+    else:
+        return v
+    return np.where(x >= 0, 2 * x, -2 * x - 1)
+
+
+def _prior_counts(rho_q: int, m_idx: int, eps_idx: int,
+                  remap: np.ndarray) -> np.ndarray:
+    geo = _geometric_pmf(rho_q)
+    return EPS_GRID[eps_idx] + M_GRID[m_idx] * geo[remap]
+
+
+def _gauss_pmf_from_q(q_u16: int) -> np.ndarray:
+    """Discrete Gaussian pmf[k] proportional to q^(k^2), k in [-128, 127].
+
+    Built with exact float64 multiplications only (binary exponentiation), so
+    it is bit-identical across IEEE platforms. Unnormalized (constriction
+    normalizes internally); underflow to 0.0 is fine (constriction floors)."""
+    q = q_u16 / 65535.0
+    out = np.empty(256, np.float64)
+    for i in range(256):
+        k = i - 128
+        e = k * k
+        acc = 1.0
+        base = q
+        while e:
+            if e & 1:
+                acc *= base
+            base *= base
+            e >>= 1
+        out[i] = acc
+    return out
+
+
+def _pmf_bits(pmf: np.ndarray, symbols: np.ndarray) -> float:
+    p = pmf / pmf.sum()
+    p = np.maximum(p, 1e-300)
+    return float(-np.log2(p[symbols]).sum())
+
+
+def _cumcount(a: np.ndarray) -> np.ndarray:
+    """out[t] = number of previous occurrences of a[t] in a[:t]."""
+    order = np.argsort(a, kind="stable")
+    sa = a[order]
+    starts = np.flatnonzero(np.concatenate([[True], sa[1:] != sa[:-1]]))
+    sizes = np.diff(np.concatenate([starts, [len(sa)]]))
+    grp = np.repeat(np.arange(len(starts)), sizes)
+    cc = np.arange(len(sa)) - starts[grp]
+    out = np.empty(len(a), np.int64)
+    out[order] = cc
+    return out
+
+
+def _sim_adaptive_bits(symbols: np.ndarray, cc: np.ndarray,
+                       prior: np.ndarray, inc: float) -> float:
+    """Exact code length of adaptive AC: P_t(s) = (a_s + inc*c) / (A + inc*t)."""
+    A = float(prior.sum())
+    n = len(symbols)
+    num = prior[symbols] + inc * cc
+    den = A + inc * np.arange(n, dtype=np.float64)
+    return float(np.log2(den).sum() - np.log2(num).sum())
+
+
+def _adaptive_dm_bits(symbols: np.ndarray, prior: np.ndarray) -> float:
+    return _sim_adaptive_bits(symbols, _cumcount(symbols), prior, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# fp16 high-byte coding (scales / mins are tightly clustered in exponent)
+# ---------------------------------------------------------------------------
+def _encode_hi_bytes(enc, hi: np.ndarray) -> bytes:
+    """Encode high bytes into `enc`; returns 2-byte (base, width) header."""
+    base = int(hi.min())
+    width = int(hi.max()) - base + 1
+    counts = np.full(width, 0.5, np.float64)
+    Cat = constriction.stream.model.Categorical
+    for v in (hi.astype(np.int64) - base).tolist():
+        enc.encode(v, Cat(counts, lazy=True))
+        counts[v] += 1.0
+    return struct.pack("<BB", base, width)
+
+
+def _decode_hi_bytes(dec, base: int, width: int, n: int) -> np.ndarray:
+    counts = np.full(width, 0.5, np.float64)
+    Cat = constriction.stream.model.Categorical
+    out = np.empty(n, np.uint8)
+    for i in range(n):
+        v = dec.decode(Cat(counts, lazy=True))
+        out[i] = base + v
+        counts[v] += 1.0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# section 1: decoder weight streams
+# ---------------------------------------------------------------------------
+def _decoder_model_plan():
+    """Per-storage-pos model key + model keys in first-use order."""
+    model_of, keys = [], {}
+    for tidx, _ in TENSOR_SCHEMA:
+        key = "shared" if tidx in SHARED_MODEL_TENSORS else f"t{tidx}"
+        model_of.append(key)
+        if key not in keys:
+            keys[key] = len(keys)
+    return model_of, keys
+
+
+def _split_streams_to_tensors(raws: list[bytes]):
+    """raws (7 streams) -> (per-pos weight byte arrays, per-pos 2B scales)."""
+    weights, scales = [], []
+    start = 0
+    for si, end in enumerate(STREAM_ENDS):
+        data = np.frombuffer(raws[si], np.uint8)
+        pos = 0
+        for p in range(start, end):
+            _tidx, numel = TENSOR_SCHEMA[p]
+            weights.append(data[pos:pos + numel].copy())
+            scales.append(bytes(data[pos + numel:pos + numel + 2]))
+            pos += numel + 2
+        if pos != len(data):
+            raise ValueError(f"stream {si} length mismatch")
+        start = end
+    return weights, scales
+
+
+def _tensors_to_streams(weights, scales) -> list[bytes]:
+    out, start = [], 0
+    for end in STREAM_ENDS:
+        parts = []
+        for p in range(start, end):
+            parts.append(weights[p].astype(np.uint8).tobytes())
+            parts.append(scales[p])
+        out.append(b"".join(parts))
+        start = end
+    return out
+
+
+def _search_model_params(m: np.ndarray) -> tuple[int, int, int, int]:
+    """Pick (rho_q, m_idx, inc_idx, eps_idx) minimizing simulated bits."""
+    cc = _cumcount(m)
+    mu = max(float(m.mean()), 0.05)
+    rho0 = int(np.clip(round(255.0 * mu / (1.0 + mu)), 1, 254))
+    best = None
+    geos = {}
+    for stage, offsets in ((0, range(-12, 13, 4)), (1, range(-3, 4, 1))):
+        center = rho0 if stage == 0 else best[1]
+        for dr in offsets:
+            rho_q = int(np.clip(center + dr, 1, 254))
+            if rho_q not in geos:
+                geos[rho_q] = _geometric_pmf(rho_q)
+            geo = geos[rho_q]
+            for m_idx, M in enumerate(M_GRID):
+                for eps_idx, eps in enumerate(EPS_GRID):
+                    prior = eps + M * geo
+                    for inc_idx, inc in enumerate(INC_GRID):
+                        bits = _sim_adaptive_bits(m, cc, prior, inc)
+                        cand = (bits, rho_q, m_idx, inc_idx, eps_idx)
+                        if best is None or cand[0] < best[0]:
+                            best = cand
+    return best[1], best[2], best[3], best[4]
+
+
+def encode_decoder_section(raws: list[bytes]) -> bytes:
+    weights, scales = _split_streams_to_tensors(raws)
+    model_of, keys = _decoder_model_plan()
+
+    model_syms = {k: [] for k in keys}
+    for pos, w in enumerate(weights):
+        tidx, _ = TENSOR_SCHEMA[pos]
+        model_syms[model_of[pos]].append(_remap_table(tidx)[w])
+    params = {k: _search_model_params(np.concatenate(model_syms[k]))
+              for k in keys}
+
+    scale_bytes = b"".join(scales)
+    lo = np.frombuffer(scale_bytes, np.uint8)[0::2]
+    hi = np.frombuffer(scale_bytes, np.uint8)[1::2]
+
+    enc = constriction.stream.queue.RangeEncoder()
+    hi_hdr = _encode_hi_bytes(enc, hi)
+
+    Cat = constriction.stream.model.Categorical
+    model_counts, model_inc = {}, {}
+    for pos, w in enumerate(weights):
+        tidx, _ = TENSOR_SCHEMA[pos]
+        key = model_of[pos]
+        if key not in model_counts:
+            rho_q, m_idx, inc_idx, eps_idx = params[key]
+            model_counts[key] = _prior_counts(rho_q, m_idx, eps_idx,
+                                              _remap_table(tidx))
+            model_inc[key] = INC_GRID[inc_idx]
+        counts, inc = model_counts[key], model_inc[key]
+        for v in w.tolist():
+            enc.encode(v, Cat(counts, lazy=True))
+            counts[v] += inc
+    body = enc.get_compressed().astype("<u4").tobytes()
+
+    hdr = [lo.tobytes(), hi_hdr]
+    hdr.append(bytes(params[k][0] for k in keys))                     # rho
+    hdr.append(bytes((params[k][1] | (params[k][2] << 3)
+                      | (params[k][3] << 5)) for k in keys))          # M|inc|eps
+    return b"".join(hdr) + body
+
+
+def decode_decoder_section(blob: bytes) -> list[bytes]:
+    model_of, keys = _decoder_model_plan()
+    n_models = len(keys)
+    p = 0
+    lo = np.frombuffer(blob[p:p + N_TENSORS], np.uint8)
+    p += N_TENSORS
+    hi_base, hi_width = struct.unpack_from("<BB", blob, p)
+    p += 2
+    rho_bytes = blob[p:p + n_models]
+    p += n_models
+    packed = blob[p:p + n_models]
+    p += n_models
+    params = {}
+    for i, k in enumerate(keys):
+        b = packed[i]
+        params[k] = (rho_bytes[i], b & 7, (b >> 3) & 3, (b >> 5) & 3)
+
+    words = np.frombuffer(blob[p:], dtype="<u4").astype(np.uint32)
+    dec = constriction.stream.queue.RangeDecoder(words)
+    hi = _decode_hi_bytes(dec, hi_base, hi_width, N_TENSORS)
+    scale_arr = np.empty(2 * N_TENSORS, np.uint8)
+    scale_arr[0::2] = lo
+    scale_arr[1::2] = hi
+    scales = [scale_arr[2 * i:2 * i + 2].tobytes() for i in range(N_TENSORS)]
+
+    Cat = constriction.stream.model.Categorical
+    model_counts, model_inc = {}, {}
+    weights = []
+    for pos, (tidx, numel) in enumerate(TENSOR_SCHEMA):
+        key = model_of[pos]
+        if key not in model_counts:
+            rho_q, m_idx, inc_idx, eps_idx = params[key]
+            model_counts[key] = _prior_counts(rho_q, m_idx, eps_idx,
+                                              _remap_table(tidx))
+            model_inc[key] = INC_GRID[inc_idx]
+        counts, inc = model_counts[key], model_inc[key]
+        out = np.empty(numel, np.uint8)
+        for i in range(numel):
+            v = dec.decode(Cat(counts, lazy=True))
+            out[i] = v
+            counts[v] += inc
+        weights.append(out)
+    return _tensors_to_streams(weights, scales)
+
+
+# ---------------------------------------------------------------------------
+# section 2: latents
+# ---------------------------------------------------------------------------
+def _latent_signed_deltas(codes: np.ndarray) -> np.ndarray:
+    d = (codes[:, 1:].astype(np.int64) - 128) & 255
+    return np.where(d >= 128, d - 256, d)
+
+
+def _fit_q_idx(res: np.ndarray) -> tuple[int, float]:
+    """Q_TABLE index minimizing exact coded bits for the residuals."""
+    sig = max(float(res.std()), 0.35)
+    k0 = int(np.clip(round(255.0 * math.log(sig / 0.3)
+                           / math.log(80.0 / 0.3)), 0, 255))
+    syms = (res + 128).astype(np.int64)
+    best = None
+    for dk in range(-14, 15, 2):
+        k = int(np.clip(k0 + dk, 0, 255))
+        bits = _pmf_bits(_gauss_pmf_from_q(Q_TABLE[k]), syms)
+        if best is None or bits < best[1]:
+            best = (k, bits)
+    k_center = best[0]
+    for dk in (-1, 1):
+        k = int(np.clip(k_center + dk, 0, 255))
+        bits = _pmf_bits(_gauss_pmf_from_q(Q_TABLE[k]), syms)
+        if bits < best[1]:
+            best = (k, bits)
+    return best
+
+
+def encode_latent_section(latent_raw: bytes) -> bytes:
+    lat = np.frombuffer(latent_raw, np.uint8)
+    if len(lat) != LATENT_HDR + LATENT_DIM * N_PAIRS:
+        raise ValueError("unexpected latent payload length")
+    hdr16 = lat[:LATENT_HDR]
+    lo = hdr16[0::2]
+    hi = hdr16[1::2]
+    codes = lat[LATENT_HDR:].reshape(LATENT_DIM, N_PAIRS)
+    first_col = bytes(codes[:, 0])
+    sd = _latent_signed_deltas(codes)  # (28, 599)
+    T = N_PAIRS - 1
+
+    C = np.corrcoef(sd.astype(np.float64))
+    own_f = sd.astype(np.float64)
+    specs, all_syms = [], []
+    for i in range(LATENT_DIM):
+        ar1 = np.concatenate([[0.0], own_f[i, :-1]])
+        lag2 = np.concatenate([[0.0, 0.0], own_f[i, :-2]])
+        lag2_corr = abs(np.corrcoef(sd[i, 2:], sd[i, :-2])[0, 1])
+        cands = sorted(range(i), key=lambda k: -abs(C[i, k]))
+        cands = [(k, abs(C[i, k])) for k in cands if abs(C[i, k]) > 0.10][:4]
+        cands.append((LAG2_SRC, lag2_corr))
+        cands.sort(key=lambda kc: -kc[1])
+        best = None
+        for ncand in range(len(cands) + 1):
+            feats = [ar1]
+            for k, _ in cands[:ncand]:
+                feats.append(lag2 if k == LAG2_SRC else own_f[k])
+            X = np.stack(feats, 1)
+            coef, *_ = np.linalg.lstsq(X, own_f[i], rcond=None)
+            cq = np.clip(np.round(coef * 64.0), -127, 127).astype(np.int64)
+            num = (X.astype(np.int64) * cq).sum(axis=1)
+            pred = (num + 32) >> 6
+            r = ((sd[i] - pred + 128) & 255) - 128
+            q_idx, bits = _fit_q_idx(r)
+            cost = bits + 8.0 * (2 * ncand)
+            if best is None or cost < best[0]:
+                best = (cost, cq, cands[:ncand], q_idx, r)
+        _, cq, used, q_idx, r = best
+        syms = (r + 128).astype(np.int64)
+        # static vs Gaussian-primed adaptive residual model
+        pmf = _gauss_pmf_from_q(Q_TABLE[q_idx])
+        static_bits = _pmf_bits(pmf, syms)
+        prior = 1e-4 + LATENT_ADAPT_M * (pmf / pmf.sum())
+        adapt_bits = _adaptive_dm_bits(syms, prior)
+        adaptive = bool(adapt_bits + 2.0 < static_bits)
+        specs.append((int(cq[0]),
+                      [(k, int(c)) for (k, _), c in zip(used, cq[1:])],
+                      q_idx, adaptive))
+        all_syms.append(syms)
+
+    out = [lo.tobytes(), first_col]
+    for ar1_q, cross, q_idx, adaptive in specs:
+        out.append(struct.pack("<Bb", q_idx, ar1_q))
+    nib = bytearray(LATENT_DIM // 2)
+    for i, (_, cross, _, adaptive) in enumerate(specs):
+        v = len(cross) | (8 if adaptive else 0)
+        nib[i // 2] |= v << (4 * (i % 2))
+    out.append(bytes(nib))
+    for _, cross, _, _ in specs:
+        for k, c in cross:
+            out.append(struct.pack("<Bb", k, c))
+
+    enc = constriction.stream.queue.RangeEncoder()
+    # mins-hi and scales-hi are two distinct exponent clusters: separate models
+    hi_hdr = _encode_hi_bytes(enc, hi[:LATENT_DIM]) \
+        + _encode_hi_bytes(enc, hi[LATENT_DIM:])
+    out.insert(1, hi_hdr)
+    Cat = constriction.stream.model.Categorical
+    for i in range(LATENT_DIM):
+        q_idx, adaptive = specs[i][2], specs[i][3]
+        pmf = _gauss_pmf_from_q(Q_TABLE[q_idx])
+        if adaptive:
+            counts = 1e-4 + LATENT_ADAPT_M * (pmf / pmf.sum())
+            for v in all_syms[i].tolist():
+                enc.encode(v, Cat(counts, lazy=True))
+                counts[v] += 1.0
+        else:
+            enc.encode(all_syms[i].astype(np.int32), Cat(pmf, perfect=False))
+    out.append(enc.get_compressed().astype("<u4").tobytes())
+    return b"".join(out)
+
+
+def decode_latent_section(blob: bytes) -> bytes:
+    p = 0
+    lo = np.frombuffer(blob[p:p + LATENT_HDR // 2], np.uint8)
+    p += LATENT_HDR // 2
+    hb0, hw0, hb1, hw1 = struct.unpack_from("<BBBB", blob, p)
+    p += 4
+    first_col = np.frombuffer(blob[p:p + LATENT_DIM], np.uint8)
+    p += LATENT_DIM
+    qa = []
+    for _ in range(LATENT_DIM):
+        q_idx, ar1 = struct.unpack_from("<Bb", blob, p)
+        p += 2
+        qa.append((q_idx, ar1))
+    nib = blob[p:p + LATENT_DIM // 2]
+    p += LATENT_DIM // 2
+    specs = []
+    for i in range(LATENT_DIM):
+        v = (nib[i // 2] >> (4 * (i % 2))) & 0xF
+        specs.append([qa[i][1], v & 7, qa[i][0], bool(v & 8)])
+    for i in range(LATENT_DIM):
+        cross = []
+        for _ in range(specs[i][1]):
+            k, c = struct.unpack_from("<Bb", blob, p)
+            p += 2
+            cross.append((k, c))
+        specs[i][1] = cross
+
+    words = np.frombuffer(blob[p:], dtype="<u4").astype(np.uint32)
+    dec = constriction.stream.queue.RangeDecoder(words)
+    hi = np.concatenate([_decode_hi_bytes(dec, hb0, hw0, LATENT_DIM),
+                         _decode_hi_bytes(dec, hb1, hw1, LATENT_DIM)])
+    hdr16 = np.empty(LATENT_HDR, np.uint8)
+    hdr16[0::2] = lo
+    hdr16[1::2] = hi
+
+    Cat = constriction.stream.model.Categorical
+    T = N_PAIRS - 1
+    sd = np.zeros((LATENT_DIM, T), np.int64)
+    for i in range(LATENT_DIM):
+        ar1, cross, q_idx, adaptive = specs[i]
+        pmf = _gauss_pmf_from_q(Q_TABLE[q_idx])
+        if adaptive:
+            counts = 1e-4 + LATENT_ADAPT_M * (pmf / pmf.sum())
+            syms = np.empty(T, np.int64)
+            for t in range(T):
+                v = dec.decode(Cat(counts, lazy=True))
+                syms[t] = v
+                counts[v] += 1.0
+        else:
+            syms = np.asarray(dec.decode(Cat(pmf, perfect=False), T),
+                              dtype=np.int64)
+        r = syms - 128
+        cross_term = np.zeros(T, np.int64)
+        lag2_coef = 0
+        for k, c in cross:
+            if k == LAG2_SRC:
+                lag2_coef = c
+            else:
+                cross_term += c * sd[k]
+        row = sd[i]
+        prev = prev2 = 0
+        for t in range(T):
+            num = ar1 * prev + lag2_coef * prev2 + int(cross_term[t])
+            pred = (num + 32) >> 6
+            v = ((r[t] + pred + 128) & 255) - 128
+            row[t] = v
+            prev2 = prev
+            prev = v
+    codes = np.empty((LATENT_DIM, N_PAIRS), np.uint8)
+    codes[:, 0] = first_col
+    codes[:, 1:] = ((sd + 128) & 255).astype(np.uint8)
+    return hdr16.tobytes() + codes.tobytes()
+
+
+# ---------------------------------------------------------------------------
+# section 3: FEC6 selector
+# ---------------------------------------------------------------------------
+def _selector_codes_from_payload(payload: bytes) -> np.ndarray:
+    if payload[:4] != SELECTOR_MAGIC:
+        raise ValueError("not a FEC6 selector payload")
+    n_pairs = struct.unpack_from("<H", payload, 4)[0]
+    decode = {b: i for i, b in enumerate(FEC6_CODE_BITS)}
+    bits = np.unpackbits(np.frombuffer(payload[6:], np.uint8))
+    codes, prefix = [], ""
+    for bit in bits:
+        prefix += "1" if bit else "0"
+        if prefix in decode:
+            codes.append(decode[prefix])
+            prefix = ""
+            if len(codes) == n_pairs:
+                break
+    if len(codes) != n_pairs:
+        raise ValueError("truncated FEC6 bitstream")
+    return np.array(codes, np.int64)
+
+
+def _selector_payload_from_codes(codes: np.ndarray) -> bytes:
+    bitstr = "".join(FEC6_CODE_BITS[c] for c in codes.tolist())
+    bitstr += "0" * ((-len(bitstr)) % 8)
+    body = int(bitstr, 2).to_bytes(len(bitstr) // 8, "big") if bitstr else b""
+    return SELECTOR_MAGIC + struct.pack("<H", len(codes)) + body
+
+
+def encode_selector_section(payload: bytes) -> bytes:
+    codes = _selector_codes_from_payload(payload)
+    enc = constriction.stream.queue.RangeEncoder()
+    Cat = constriction.stream.model.Categorical
+    counts = np.full(16, 0.6, np.float64)
+    for c in codes.tolist():
+        enc.encode(c, Cat(counts, lazy=True))
+        counts[c] += 1.0
+    return enc.get_compressed().astype("<u4").tobytes()
+
+
+def decode_selector_section(blob: bytes) -> bytes:
+    words = np.frombuffer(blob, dtype="<u4").astype(np.uint32)
+    dec = constriction.stream.queue.RangeDecoder(words)
+    Cat = constriction.stream.model.Categorical
+    counts = np.full(16, 0.6, np.float64)
+    codes = np.empty(N_PAIRS, np.int64)
+    for i in range(N_PAIRS):
+        c = dec.decode(Cat(counts, lazy=True))
+        codes[i] = c
+        counts[c] += 1.0
+    return _selector_payload_from_codes(codes)
+
+
+# ---------------------------------------------------------------------------
+# container
+# ---------------------------------------------------------------------------
+def pack_container(decoder_sec: bytes, latent_sec: bytes, selector_sec: bytes,
+                   coder_ids: tuple[int, int, int]) -> bytes:
+    head = bytes([(VERSION << 4) | coder_ids[0] | (coder_ids[1] << 1)
+                  | (coder_ids[2] << 2)])
+    head += len(decoder_sec).to_bytes(3, "little")
+    head += len(latent_sec).to_bytes(3, "little")
+    return head + decoder_sec + latent_sec + selector_sec
+
+
+def unpack_container(blob: bytes):
+    """-> (decoder_streams: list[bytes], latent_raw: bytes, selector: bytes)."""
+    if blob[0] >> 4 != VERSION:
+        raise ValueError("bad container version")
+    ids = (blob[0] & 1, (blob[0] >> 1) & 1, (blob[0] >> 2) & 1)
+    ld = int.from_bytes(blob[1:4], "little")
+    ll = int.from_bytes(blob[4:7], "little")
+    p = 7
+    dec_sec = blob[p:p + ld]
+    p += ld
+    lat_sec = blob[p:p + ll]
+    p += ll
+    sel_sec = blob[p:]
+
+    if ids[0] == CODER_CTX:
+        streams = decode_decoder_section(dec_sec)
+    else:
+        streams = _split_legacy_brotli(dec_sec)
+    if ids[1] == CODER_CTX:
+        latent_raw = decode_latent_section(lat_sec)
+    else:
+        import lzma
+        latent_raw = lzma.decompress(
+            lat_sec, format=lzma.FORMAT_RAW,
+            filters=[{"id": lzma.FILTER_LZMA1, "dict_size": 4096,
+                      "lc": 3, "lp": 0, "pb": 0}])
+    selector = decode_selector_section(sel_sec) if ids[2] == CODER_CTX else sel_sec
+    return streams, latent_raw, selector
+
+
+def _split_legacy_brotli(data: bytes) -> list[bytes]:
+    import brotli
+    out, pos = [], 0
+    for _ in range(N_STREAMS):
+        dec = brotli.Decompressor()
+        chunks = []
+        while pos < len(data) and not dec.is_finished():
+            chunks.append(dec.process(data[pos:pos + 1]))
+            pos += 1
+        if not dec.is_finished():
+            raise ValueError("truncated legacy decoder payload")
+        out.append(b"".join(chunks))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# reporting
+# ---------------------------------------------------------------------------
+def summary_table(rows: list[tuple[str, int, int]]) -> str:
+    """rows: (section, current_bytes, new_bytes) -> formatted table."""
+    lines = [f"{'section':<12} {'current':>10} {'ctx-coder':>10} {'delta':>8}"]
+    tc = tn = 0
+    for name, cur, new in rows:
+        tc += cur
+        tn += new
+        lines.append(f"{name:<12} {cur:>10,} {new:>10,} {new - cur:>+8,}")
+    lines.append(f"{'TOTAL':<12} {tc:>10,} {tn:>10,} {tn - tc:>+8,}")
+    return "\n".join(lines)

--- a/submissions/rhnerv_comma/codec_sidecar.py
+++ b/submissions/rhnerv_comma/codec_sidecar.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+"""Latent sidecar decoding for the 607-byte PR #101 enum-rank format.
+
+Ported from `submissions/hnerv_fec6_fixed_huffman_k16/src/codec_sidecar.py`
+(PR #110, @adpena, MIT; decode grammar by PR #101, @SajayR). This submission
+carries the #101 sidecar VERBATIM (607 bytes, enum-ranked canonical Huffman
+with inferred no-op positions), so only that format's decode path is kept.
+All retained function bodies are verbatim fec6; the legacy/raw/Brotli sidecar
+formats were dropped, which removes the inflate-time `brotli` dependency.
+"""
+
+from functools import lru_cache
+import math
+
+import numpy as np
+import torch
+
+
+N_PAIRS = 600
+LATENT_DIM = 28
+SIDECAR_DELTAS_X100 = np.array(
+    [-10, -8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8, 10],
+    dtype=np.int8,
+)
+SIDECAR_HUFF_ENUM_LEN = 607
+SIDECAR_NOOP_INFER_RANK_LEN = 3
+SIDECAR_DIM_PACKED_LEN = 359
+SIDECAR_DELTA_HUFF_LENGTH_RANK_LEN = 5
+SIDECAR_HUFF_MIN_LEN = 2
+SIDECAR_HUFF_MAX_LEN = 8
+SIDECAR_HUFF_KRAFT_TOTAL = 1 << SIDECAR_HUFF_MAX_LEN
+
+
+def decode_canonical_huffman_all(data, lengths):
+    """Decode a complete canonical Huffman stream and reject dangling bits."""
+    decode = {}
+    code = 0
+    prev_len = 0
+    for sym, length in sorted(
+        ((sym, int(length)) for sym, length in enumerate(lengths) if length),
+        key=lambda x: (x[1], x[0]),
+    ):
+        code <<= length - prev_len
+        decode[(length, code)] = sym
+        code += 1
+        prev_len = length
+
+    out = []
+    cur = 0
+    cur_len = 0
+    for byte in data:
+        for shift in range(7, -1, -1):
+            cur = (cur << 1) | ((byte >> shift) & 1)
+            cur_len += 1
+            sym = decode.get((cur_len, cur))
+            if sym is not None:
+                out.append(sym)
+                cur = 0
+                cur_len = 0
+    if cur_len:
+        raise ValueError("truncated Huffman sidecar")
+    return np.array(out, dtype=np.uint8)
+
+
+@lru_cache(None)
+def huff_length_vector_count(pos, remaining):
+    """Count remaining valid canonical length vectors for rank decoding."""
+    if pos == len(SIDECAR_DELTAS_X100):
+        return int(remaining == 0)
+    total = 0
+    for length in range(SIDECAR_HUFF_MIN_LEN, SIDECAR_HUFF_MAX_LEN + 1):
+        weight = 1 << (SIDECAR_HUFF_MAX_LEN - length)
+        if remaining >= weight:
+            total += huff_length_vector_count(pos + 1, remaining - weight)
+    return total
+
+
+def decode_huff_length_rank(rank):
+    """Recover a canonical Huffman length vector from its colex rank."""
+    if rank >= huff_length_vector_count(0, SIDECAR_HUFF_KRAFT_TOTAL):
+        raise ValueError("bad Huffman length-vector rank")
+    lengths = np.empty(len(SIDECAR_DELTAS_X100), dtype=np.uint8)
+    remaining = SIDECAR_HUFF_KRAFT_TOTAL
+    for pos in range(lengths.size):
+        for length in range(SIDECAR_HUFF_MIN_LEN, SIDECAR_HUFF_MAX_LEN + 1):
+            weight = 1 << (SIDECAR_HUFF_MAX_LEN - length)
+            if remaining < weight:
+                continue
+            block = huff_length_vector_count(pos + 1, remaining - weight)
+            if rank >= block:
+                rank -= block
+            else:
+                lengths[pos] = length
+                remaining -= weight
+                break
+        else:
+            raise ValueError("bad Huffman length-vector rank")
+    if remaining or rank:
+        raise ValueError("bad Huffman length-vector rank")
+    return lengths
+
+
+def decode_combination_colex(rank, n, k):
+    """Decode a k-of-n combination from colexicographic rank."""
+    if rank >= math.comb(n, k):
+        raise ValueError("bad combination rank")
+    combo = [0] * k
+    x = n
+    for i in range(k, 0, -1):
+        x -= 1
+        while math.comb(x, i) > rank:
+            x -= 1
+        combo[i - 1] = x
+        rank -= math.comb(x, i)
+    if rank:
+        raise ValueError("bad combination rank")
+    return np.array(combo, dtype=np.int64)
+
+
+def _packed_dims(value, n_valid, *, error_message):
+    """Recover little-endian base-LATENT_DIM sidecar dimensions."""
+    dims_valid = np.empty(n_valid, dtype=np.int64)
+    for i in range(n_valid):
+        value, dims_valid[i] = divmod(value, LATENT_DIM)
+    if value:
+        raise ValueError(error_message)
+    return dims_valid
+
+
+def _vectors_from_valid(valid_mask, dims_valid, delta_valid):
+    """Materialize full per-pair sidecar vectors from valid pair entries."""
+    dims = np.full(N_PAIRS, 255, dtype=np.int64)
+    codes = np.zeros(N_PAIRS, dtype=np.float32)
+    dims[valid_mask] = dims_valid
+    codes[valid_mask] = SIDECAR_DELTAS_X100[delta_valid].astype(np.float32)
+    return dims, codes
+
+
+def _decode_enum_rank_sidecar(raw, arr_size):
+    """Decode enum-ranked Huffman sidecar with inferred no-op positions."""
+    dim_end = SIDECAR_DIM_PACKED_LEN
+    rank_end = dim_end + SIDECAR_DELTA_HUFF_LENGTH_RANK_LEN
+    length_rank = int.from_bytes(raw[dim_end:rank_end], "little")
+    lengths = decode_huff_length_rank(length_rank)
+
+    noop_rank_start = arr_size - SIDECAR_NOOP_INFER_RANK_LEN
+    delta_valid = decode_canonical_huffman_all(
+        raw[rank_end:noop_rank_start], lengths
+    ).astype(np.int64)
+    n_valid = delta_valid.size
+    noop_count = N_PAIRS - n_valid
+    if noop_count < 0:
+        raise ValueError("bad compact Huffman sidecar length")
+
+    noop_rank = int.from_bytes(raw[noop_rank_start:], "little")
+    noop_pos = decode_combination_colex(noop_rank, N_PAIRS, noop_count)
+    valid_mask = np.ones(N_PAIRS, dtype=bool)
+    valid_mask[noop_pos] = False
+    if int(valid_mask.sum()) != n_valid:
+        raise ValueError("bad compact Huffman sidecar no-op count")
+
+    dims_valid = _packed_dims(
+        int.from_bytes(raw[:dim_end], "little"),
+        n_valid,
+        error_message="bad compact Huffman sidecar dimensions",
+    )
+    return _vectors_from_valid(valid_mask, dims_valid, delta_valid)
+
+
+def apply_latent_sidecar(latents, data):
+    """Apply archive-local latent corrections without changing decoder math."""
+    if not data:
+        return latents
+    if len(data) != SIDECAR_HUFF_ENUM_LEN:
+        raise ValueError("this submission only carries the 607-byte "
+                         "enum-rank sidecar format")
+    dims, codes = _decode_enum_rank_sidecar(data, len(data))
+    valid = dims != 255
+    if np.any(dims[valid] >= LATENT_DIM):
+        raise ValueError("bad latent sidecar dimension")
+    if valid.any():
+        row = torch.from_numpy(np.nonzero(valid)[0])
+        col = torch.from_numpy(dims[valid])
+        delta = torch.from_numpy(codes[valid] / 100.0).to(latents.dtype)
+        latents = latents.clone()
+        latents[row, col] += delta
+    return latents

--- a/submissions/rhnerv_comma/compress.py
+++ b/submissions/rhnerv_comma/compress.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Rebuild this submission's archive.zip from the pinned upstream archives.
+
+Inputs (verified by SHA-256 before use, never redistributed):
+  PR #101 archive.zip  b83bf3488625dbd73adeddff91712994197ab53098e578e91327a0c6e49efb3e
+  PR #110 archive.zip  6bae0201fb082457a02c69565531aba4c5942669c384fdc48e7d554f7b893fcf
+
+Pipeline (deterministic; the ctx coder uses only IEEE-exact float64 model
+construction, so the output bytes are platform-independent):
+  1. #101 member `x` -> decoder Brotli blob / latent LZMA blob / 607-B sidecar.
+  2. decode the entropy layers back to RAW bytes (7 decoder streams, 16,912-B
+     latent payload). These raw bytes are the information content.
+  3. #110 member `x` -> trailing 249-B FEC6 selector wire payload (and a
+     cross-check that #110 embeds #101's source payload byte-for-byte).
+  4. re-code each section with the ctx coder (codec_ctx), per-section best-of
+     {ctx, passthrough}; decode everything back and assert byte equality.
+  5. member = ctx container ++ verbatim sidecar; zip as single member `x`,
+     ZIP_STORED, fixed 1980-01-01 timestamp.
+
+Encode-side deps: numpy, constriction, brotli (all present in the challenge
+repo's `--group cpu` environment). torch is NOT needed to compress.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import lzma
+import sys
+import zipfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import codec_ctx as cc  # type: ignore[import-not-found]
+
+PR101_SHA256 = "b83bf3488625dbd73adeddff91712994197ab53098e578e91327a0c6e49efb3e"
+PR110_SHA256 = "6bae0201fb082457a02c69565531aba4c5942669c384fdc48e7d554f7b893fcf"
+
+PR101_MEMBER_LEN = 178_158
+DECODER_BLOB_LEN = 162_164
+LATENT_BLOB_LEN = 15_387
+SIDECAR_LEN = 607
+SELECTOR_LEN = 249
+DECODER_RAW_LEN = 229_014
+LATENT_RAW_LEN = 16_912
+FP11_HEADER_LEN = 8  # b"FP11" + u32 source_len
+
+EXPECTED_MEMBER_LEN = 177_036
+EXPECTED_ARCHIVE_LEN = 177_136
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def check_input(path: Path, want_sha: str, label: str) -> None:
+    got = sha256_file(path)
+    if got != want_sha:
+        raise SystemExit(f"ERROR: {label} SHA-256 mismatch\n  got  {got}\n  want {want_sha}")
+    print(f"{label}: SHA-256 OK ({path})")
+
+
+def write_stored_zip(zip_path: Path, member_name: str, payload: bytes) -> None:
+    info = zipfile.ZipInfo(member_name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.compress_type = zipfile.ZIP_STORED
+    info.external_attr = 0o644 << 16
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr(info, payload)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pr101", type=Path, required=True, help="PR #101 archive.zip")
+    ap.add_argument("--pr110", type=Path, required=True, help="PR #110 archive.zip")
+    ap.add_argument("--out", type=Path, default=HERE / "archive.zip")
+    args = ap.parse_args()
+
+    check_input(args.pr101, PR101_SHA256, "PR #101 archive")
+    check_input(args.pr110, PR110_SHA256, "PR #110 archive")
+
+    # ---- 1/2: extract + entropy-decode the #101 payload sections ----
+    payload101 = zipfile.ZipFile(args.pr101).read("x")
+    assert len(payload101) == PR101_MEMBER_LEN, len(payload101)
+    decoder_blob = payload101[:DECODER_BLOB_LEN]
+    latent_blob = payload101[DECODER_BLOB_LEN:DECODER_BLOB_LEN + LATENT_BLOB_LEN]
+    sidecar = payload101[DECODER_BLOB_LEN + LATENT_BLOB_LEN:]
+    assert len(sidecar) == SIDECAR_LEN, len(sidecar)
+
+    raws = cc._split_legacy_brotli(decoder_blob)
+    assert sum(len(r) for r in raws) == DECODER_RAW_LEN
+    latent_raw = lzma.decompress(
+        latent_blob, format=lzma.FORMAT_RAW,
+        filters=[{"id": lzma.FILTER_LZMA1, "dict_size": 4096,
+                  "lc": 3, "lp": 0, "pb": 0}])
+    assert len(latent_raw) == LATENT_RAW_LEN
+
+    # ---- 3: extract the FEC6 selector from #110 + lineage cross-check ----
+    payload110 = zipfile.ZipFile(args.pr110).read("x")
+    assert payload110[:4] == b"FP11"
+    assert payload110[FP11_HEADER_LEN:FP11_HEADER_LEN + PR101_MEMBER_LEN] == payload101, \
+        "#110 does not embed #101's source payload byte-for-byte"
+    selector = payload110[-SELECTOR_LEN:]
+    assert selector[:4] == b"FEC6"
+
+    # ---- 4: re-code with the ctx coder, per-section best-of ----
+    print("encoding (deterministic, ~1-2 min) ...")
+    sections = [
+        ("decoder", decoder_blob, cc.encode_decoder_section(raws)),
+        ("latents", latent_blob, cc.encode_latent_section(latent_raw)),
+        ("selector", selector, cc.encode_selector_section(selector)),
+    ]
+    chosen, ids = [], []
+    for name, cur, new in sections:
+        win = len(new) < len(cur)
+        chosen.append(new if win else cur)
+        ids.append(cc.CODER_CTX if win else cc.CODER_PASSTHROUGH)
+        print(f"  {name:<8} {len(cur):>7,} -> {len(new):>7,} B "
+              f"[{'ctx' if win else 'passthrough'}]")
+
+    container = cc.pack_container(*chosen, coder_ids=tuple(ids))
+
+    # decode-side round trip must be byte-exact before we ship anything
+    s2, l2, sel2 = cc.unpack_container(container)
+    assert all(a == b for a, b in zip(raws, s2)) and len(s2) == len(raws)
+    assert l2 == latent_raw
+    assert sel2 == selector
+    print("round-trip: all sections byte-exact")
+
+    # ---- 5: member = container ++ verbatim sidecar; deterministic zip ----
+    member = container + sidecar
+    if len(member) != EXPECTED_MEMBER_LEN:
+        print(f"WARNING: member is {len(member):,} B, expected "
+              f"{EXPECTED_MEMBER_LEN:,} B (container {len(container):,} "
+              f"+ sidecar {len(sidecar)})")
+    write_stored_zip(args.out, "x", member)
+
+    size = args.out.stat().st_size
+    print(f"{args.out}: {size:,} B (member {len(member):,} B = container "
+          f"{len(container):,} + sidecar {len(sidecar)}; zip overhead {size - len(member)})")
+    print(f"archive SHA-256: {sha256_file(args.out)}")
+    if size != EXPECTED_ARCHIVE_LEN:
+        print(f"WARNING: archive is {size:,} B, expected {EXPECTED_ARCHIVE_LEN:,} B")
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/rhnerv_comma/compress.sh
+++ b/submissions/rhnerv_comma/compress.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Rebuild archive.zip from the pinned PR #101 / PR #110 release archives.
+#
+# Usage: compress.sh [--pr101 PATH] [--pr110 PATH] [--workdir DIR] [--out PATH]
+#
+# If --pr101/--pr110 are not given, the archives are downloaded with curl into
+# the workdir and SHA-256-verified there (compress.py re-verifies them again
+# before use either way). Run inside the challenge environment, e.g.:
+#   cd <challenge-repo> && uv run --no-sync --group cpu \
+#     bash <this-dir>/compress.sh
+# Encode-side deps: numpy, constriction, brotli (no torch needed).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PR101_URL="https://github.com/SajayR/comma_video_compression_challenge/releases/download/hnerv-ft-microcodec-v1/archive.zip"
+PR110_URL="https://github.com/adpena/comma_video_compression_challenge/releases/download/fec6-frontier-submission-20260520/archive.zip"
+PR101_SHA256="b83bf3488625dbd73adeddff91712994197ab53098e578e91327a0c6e49efb3e"
+PR110_SHA256="6bae0201fb082457a02c69565531aba4c5942669c384fdc48e7d554f7b893fcf"
+
+PR101=""
+PR110=""
+WORKDIR="${HERE}/build"
+OUT="${HERE}/archive.zip"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr101)   PR101="$2"; shift 2 ;;
+    --pr110)   PR110="$2"; shift 2 ;;
+    --workdir) WORKDIR="$2"; shift 2 ;;
+    --out)     OUT="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -n "${PACT_PYTHON_BIN:-}" ]; then
+  PYTHON_BIN="$PACT_PYTHON_BIN"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN=python
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=python3
+else
+  echo "ERROR: neither python nor python3 is available" >&2
+  exit 127
+fi
+
+fetch() { # fetch <url> <dest> <sha256>
+  local url="$1" dest="$2" sha="$3"
+  if [ ! -f "$dest" ]; then
+    echo "downloading $url"
+    curl -fsSL -o "$dest" "$url"
+  fi
+  echo "${sha}  ${dest}" | sha256sum -c -
+}
+
+if [ -z "$PR101" ]; then
+  mkdir -p "$WORKDIR"
+  PR101="${WORKDIR}/pr101_archive.zip"
+  fetch "$PR101_URL" "$PR101" "$PR101_SHA256"
+fi
+if [ -z "$PR110" ]; then
+  mkdir -p "$WORKDIR"
+  PR110="${WORKDIR}/pr110_archive.zip"
+  fetch "$PR110_URL" "$PR110" "$PR110_SHA256"
+fi
+
+"$PYTHON_BIN" "$HERE/compress.py" --pr101 "$PR101" --pr110 "$PR110" --out "$OUT"

--- a/submissions/rhnerv_comma/expected_output.sha256
+++ b/submissions/rhnerv_comma/expected_output.sha256
@@ -1,0 +1,11 @@
+# Canonical reproducibility token for this submission.
+# Running `inflate.sh <unzipped-archive-dir> <out> public_test_video_names.txt`
+# on CPU with the same archive bytes (SHA-256
+# dd4f3899b91f5b59df90b4bf4fc4d903099a286548339f5f65ff91e4b8146aa4)
+# must reproduce this 0.raw SHA-256 exactly on this machine (AMD Zen 5).
+# The LSBs of CPU bicubic interpolation are microarchitecture-dependent, so
+# other hosts produce a different (locally deterministic) hash; the decode
+# math is identical to PR #110's, so on any given host this submission's
+# 0.raw is byte-identical to PR #110's (the #110 author's machine yields
+# d1afc583b01ff4a7aaa844d4f03ece3ed381d56763a06cb2c5e011526e5f868c).
+e592c742dfd64fd8d8d42c83ad7066f8c012ed677cbb55644e1e57381106040a  0.raw

--- a/submissions/rhnerv_comma/frame_selector.py
+++ b/submissions/rhnerv_comma/frame_selector.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+"""Frame-exploit selector grammar and deterministic frame-0 transforms."""
+
+from __future__ import annotations
+
+import math
+import struct
+
+import torch
+
+
+SELECTOR_MAGIC = b"FES1"
+
+# INNOVATION (sister of inflate.py INNOVATION 1): canonical 31-mode palette superset for the frame-exploit
+# selector. FEC6's active K=16 subset (see inflate.py FEC6_FIXED_K16_MODE_IDS) is drawn from this palette;
+# earlier FES1 / FEC2 / FEC3 formats use the full 31 modes. Modes are deterministic transforms on frame-0
+# (luma bias / RGB bias / blue chroma amp / roll) or frame-1 (sister modes for late-pair adjustment).
+PALETTE_MODE_IDS = (
+    "none",
+    "frame0_luma_bias_-4",
+    "frame0_luma_bias_-2",
+    "frame0_luma_bias_-1",
+    "frame0_luma_bias_+1",
+    "frame0_luma_bias_+2",
+    "frame0_luma_bias_+4",
+    "frame0_rgb_bias_p0_m1_p1",
+    "frame0_rgb_bias_p0_p1_m1",
+    "frame0_rgb_bias_p2_m1_m1",
+    "frame0_rgb_bias_m2_p1_p1",
+    "frame0_rgb_bias_p0_m2_p2",
+    "frame0_rgb_bias_p0_p2_m2",
+    "frame0_rgb_bias_p4_m2_m2",
+    "frame0_rgb_bias_m4_p2_p2",
+    "frame0_blue_chroma_amp_1",
+    "frame0_blue_chroma_amp_2",
+    "frame0_blue_chroma_amp_3",
+    "frame0_roll_dx+1_dy+0",
+    "frame0_roll_dx-1_dy+0",
+    "frame0_roll_dx+0_dy+1",
+    "frame0_roll_dx+0_dy-1",
+    "frame1_rgb_bias_p2_m1_m1",
+    "frame1_rgb_bias_m2_p1_p1",
+    "frame1_luma_bias_-1",
+    "frame1_blue_chroma_amp_3",
+    "frame1_rgb_bias_p0_m1_p1",
+    "frame1_rgb_bias_p0_p1_m1",
+    "frame1_luma_bias_+1",
+    "frame1_blue_chroma_amp_1",
+    "frame1_luma_bias_-2",
+)
+
+MODE_PARAMS: dict[str, tuple[str, tuple[int, ...]]] = {
+    "none": ("identity", ()),
+    "frame0_luma_bias_-4": ("rgb_bias", (-4, -4, -4)),
+    "frame0_luma_bias_-2": ("rgb_bias", (-2, -2, -2)),
+    "frame0_luma_bias_-1": ("rgb_bias", (-1, -1, -1)),
+    "frame0_luma_bias_+1": ("rgb_bias", (1, 1, 1)),
+    "frame0_luma_bias_+2": ("rgb_bias", (2, 2, 2)),
+    "frame0_luma_bias_+4": ("rgb_bias", (4, 4, 4)),
+    "frame0_rgb_bias_p0_m1_p1": ("rgb_bias", (0, -1, 1)),
+    "frame0_rgb_bias_p0_p1_m1": ("rgb_bias", (0, 1, -1)),
+    "frame0_rgb_bias_p2_m1_m1": ("rgb_bias", (2, -1, -1)),
+    "frame0_rgb_bias_m2_p1_p1": ("rgb_bias", (-2, 1, 1)),
+    "frame0_rgb_bias_p0_m2_p2": ("rgb_bias", (0, -2, 2)),
+    "frame0_rgb_bias_p0_p2_m2": ("rgb_bias", (0, 2, -2)),
+    "frame0_rgb_bias_p4_m2_m2": ("rgb_bias", (4, -2, -2)),
+    "frame0_rgb_bias_m4_p2_p2": ("rgb_bias", (-4, 2, 2)),
+    "frame0_blue_chroma_amp_1": ("blue_chroma", (1,)),
+    "frame0_blue_chroma_amp_2": ("blue_chroma", (2,)),
+    "frame0_blue_chroma_amp_3": ("blue_chroma", (3,)),
+    "frame0_roll_dx+1_dy+0": ("roll", (1, 0)),
+    "frame0_roll_dx-1_dy+0": ("roll", (-1, 0)),
+    "frame0_roll_dx+0_dy+1": ("roll", (0, 1)),
+    "frame0_roll_dx+0_dy-1": ("roll", (0, -1)),
+    "frame1_rgb_bias_p2_m1_m1": ("rgb_bias", (2, -1, -1)),
+    "frame1_rgb_bias_m2_p1_p1": ("rgb_bias", (-2, 1, 1)),
+    "frame1_luma_bias_-1": ("rgb_bias", (-1, -1, -1)),
+    "frame1_blue_chroma_amp_3": ("blue_chroma", (3,)),
+    "frame1_rgb_bias_p0_m1_p1": ("rgb_bias", (0, -1, 1)),
+    "frame1_rgb_bias_p0_p1_m1": ("rgb_bias", (0, 1, -1)),
+    "frame1_luma_bias_+1": ("rgb_bias", (1, 1, 1)),
+    "frame1_blue_chroma_amp_1": ("blue_chroma", (1,)),
+    "frame1_luma_bias_-2": ("rgb_bias", (-2, -2, -2)),
+}
+
+
+def _bits_per_selector(palette_size: int) -> int:
+    return max(1, math.ceil(math.log2(max(int(palette_size), 2))))
+
+
+def unpack_selector_indices(payload: bytes) -> list[int]:
+    """Decode the compact ``FES1`` little-endian bit-packed selector payload."""
+
+    if len(payload) < 10:
+        raise ValueError("selector payload truncated before header")
+    magic, n_pairs, palette_size, bits_per_index, packed_len = struct.unpack_from(
+        "<4sHBBH", payload, 0
+    )
+    if magic != SELECTOR_MAGIC:
+        raise ValueError(f"selector magic mismatch: {magic!r}")
+    expected_bits = _bits_per_selector(palette_size)
+    if bits_per_index != expected_bits:
+        raise ValueError(
+            f"selector bits_per_index={bits_per_index}, expected {expected_bits}"
+        )
+    if palette_size != len(PALETTE_MODE_IDS):
+        raise ValueError(
+            f"selector palette_size={palette_size}, runtime palette={len(PALETTE_MODE_IDS)}"
+        )
+    packed = payload[10 : 10 + packed_len]
+    if len(packed) != packed_len or len(payload) != 10 + packed_len:
+        raise ValueError("selector payload length mismatch")
+    expected_packed_len = math.ceil(n_pairs * bits_per_index / 8)
+    if packed_len != expected_packed_len:
+        raise ValueError(
+            f"selector packed_len={packed_len}, expected {expected_packed_len}"
+        )
+
+    indices: list[int] = []
+    accumulator = 0
+    nbits = 0
+    cursor = 0
+    mask = (1 << bits_per_index) - 1
+    for _ in range(n_pairs):
+        while nbits < bits_per_index:
+            if cursor >= len(packed):
+                raise ValueError("selector bitstream truncated")
+            accumulator |= int(packed[cursor]) << nbits
+            cursor += 1
+            nbits += 8
+        idx = accumulator & mask
+        accumulator >>= bits_per_index
+        nbits -= bits_per_index
+        if idx >= palette_size:
+            raise ValueError(f"selector index {idx} out of range {palette_size}")
+        indices.append(idx)
+    if accumulator != 0:
+        raise ValueError("selector bitstream has non-zero trailing bits")
+    return indices
+
+
+def _blue_tile(height: int, width: int, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    tile = torch.tensor(
+        [
+            [-1, 1, -1, 1, 1, -1, 1, -1],
+            [1, -1, 1, -1, -1, 1, -1, 1],
+            [-1, 1, 1, -1, 1, -1, -1, 1],
+            [1, -1, -1, 1, -1, 1, 1, -1],
+            [1, 1, -1, -1, 1, 1, -1, -1],
+            [-1, -1, 1, 1, -1, -1, 1, 1],
+            [1, -1, -1, 1, 1, -1, -1, 1],
+            [-1, 1, 1, -1, -1, 1, 1, -1],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    reps_h = (height + 7) // 8
+    reps_w = (width + 7) // 8
+    return tile.repeat(reps_h, reps_w)[:height, :width]
+
+
+def apply_frame0_mode(frame_chw: torch.Tensor, mode_id: str) -> torch.Tensor:
+    family, params = MODE_PARAMS[mode_id]
+    if family == "identity":
+        return frame_chw
+    out = frame_chw.clone()
+    if family == "rgb_bias":
+        delta = torch.tensor(params, dtype=out.dtype, device=out.device).view(3, 1, 1)
+        return out + delta
+    if family == "blue_chroma":
+        amp = float(params[0])
+        _channels, height, width = out.shape
+        tile = _blue_tile(height, width, device=out.device, dtype=out.dtype)
+        out[0].add_(tile * amp)
+        out[2].sub_(tile * amp)
+        return out
+    if family == "roll":
+        dx, dy = int(params[0]), int(params[1])
+        return torch.roll(out, shifts=(dy, dx), dims=(1, 2))
+    raise ValueError(f"unsupported frame-exploit mode family {family!r}")
+
+
+def apply_selector_to_frames(
+    frames_bchw: torch.Tensor,
+    selector_indices: list[int],
+    *,
+    pair_start: int,
+) -> torch.Tensor:
+    """Apply archive-packed per-pair frame-0 selector modes to a flat frame batch."""
+
+    if frames_bchw.shape[0] % 2 != 0:
+        raise ValueError("frame-exploit selector expects complete frame pairs")
+    out = frames_bchw.clone()
+    n_pairs = frames_bchw.shape[0] // 2
+    for offset in range(n_pairs):
+        pair_index = pair_start + offset
+        if pair_index >= len(selector_indices):
+            raise ValueError(
+                f"selector has {len(selector_indices)} entries; missing pair {pair_index}"
+            )
+        mode_id = PALETTE_MODE_IDS[int(selector_indices[pair_index])]
+        if mode_id == "none":
+            continue
+        frame_offset = offset * 2 + (1 if mode_id.startswith("frame1_") else 0)
+        out[frame_offset] = apply_frame0_mode(out[frame_offset], mode_id)
+    return out.clamp_(0.0, 255.0).round_()
+
+
+__all__ = [
+    "PALETTE_MODE_IDS",
+    "apply_frame0_mode",
+    "apply_selector_to_frames",
+    "unpack_selector_indices",
+]

--- a/submissions/rhnerv_comma/inflate.py
+++ b/submissions/rhnerv_comma/inflate.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Inflate the rhnerv_comma archive: PR #110's exact decoded output, with the
+payload losslessly re-coded by a context-modeled range coder.
+
+Member layout (single ZIP member `x`, ZIP_STORED):
+  [ctx container: 7-byte header | decoder section | latent section |
+   selector section] ++ [verbatim 607-byte PR #101 latent sidecar]
+
+The ctx container (`codec_ctx.unpack_container`) reproduces, bit-exactly:
+  - the 7 raw decoder weight streams of PR #101 (after its Brotli layer),
+  - the raw latent payload of PR #101 (after its LZMA layer),
+  - the 249-byte FEC6 selector wire payload of PR #110.
+The sidecar is carried verbatim and is length-implicit trailing bytes (607,
+constant in code), mirroring #101's own trailing-sidecar convention.
+
+Everything from the reconstructed bytes to pixels is the EXACT fec6 (#110)
+inflate chain -- HNeRVDecoder, 16-pair batches, bicubic 874x1164 upsample
+(align_corners=False), the #98 channel biases (frame0 R-=1, frame0 B-=1,
+frame1 G-=1), clamp(0,255).round(), then the per-pair FEC6 selector
+transforms (applied AFTER bias+clamp+round, with a final batch
+clamp_/round_), uint8, NHWC, streamed write -- so the decoded 0.raw is
+byte-identical to PR #110's on the same hardware. Device pinned to CPU.
+
+Inflate-time deps: numpy, torch, constriction (all in the harness base env).
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import codec_ctx  # type: ignore[import-not-found]
+from codec import (  # type: ignore[import-not-found]
+    BASE_CHANNELS,
+    EVAL_SIZE,
+    LATENT_DIM,
+    N_PAIRS,
+    decode_decoder_compact,
+    decode_latents_compact,
+)
+from codec_sidecar import SIDECAR_HUFF_ENUM_LEN, apply_latent_sidecar  # type: ignore[import-not-found]
+from frame_selector import _blue_tile as selector_blue_tile  # type: ignore[import-not-found]
+from model import HNeRVDecoder  # type: ignore[import-not-found]
+
+
+CAMERA_H, CAMERA_W = 874, 1164
+
+# --- FEC6 K=16 selector grammar, verbatim from fec6 inflate.py (PR #110) ---
+FEC6_FIXED_K16_MODE_IDS = (
+    "none",
+    "frame0_blue_chroma_amp_1",
+    "frame0_blue_chroma_amp_3",
+    "frame0_luma_bias_+1",
+    "frame0_luma_bias_-1",
+    "frame0_luma_bias_-2",
+    "frame0_luma_bias_-4",
+    "frame0_rgb_bias_m2_p1_p1",
+    "frame0_rgb_bias_m4_p2_p2",
+    "frame0_rgb_bias_p0_m1_p1",
+    "frame0_rgb_bias_p0_m2_p2",
+    "frame0_rgb_bias_p0_p1_m1",
+    "frame0_rgb_bias_p0_p2_m2",
+    "frame0_rgb_bias_p2_m1_m1",
+    "frame0_rgb_bias_p4_m2_m2",
+    "frame0_roll_dx+0_dy+1",
+)
+FEC6_FIXED_K16_CODE_BITS = (
+    "00",
+    "1100",
+    "01",
+    "111010",
+    "11010",
+    "111011",
+    "111100",
+    "100",
+    "111101",
+    "11011",
+    "1111110",
+    "111110",
+    "11111110",
+    "101",
+    "11100",
+    "11111111",
+)
+FEC6_FIXED_K16_DECODE = {bits: code for code, bits in enumerate(FEC6_FIXED_K16_CODE_BITS)}
+
+
+def parse_signed_token(token: str) -> int:
+    if token.startswith("p"):
+        return int(token[1:])
+    if token.startswith("m"):
+        return -int(token[1:])
+    return int(token)
+
+
+def mode_spec_from_static_mode_id(mode_id: str) -> tuple[str, tuple[int, ...], int]:
+    if mode_id == "none":
+        return ("identity", (), 0)
+    frame_index = 1 if mode_id.startswith("frame1_") else 0
+    base = mode_id.replace("frame1_", "frame0_", 1)
+    if base.startswith("frame0_luma_bias_"):
+        value = int(base.removeprefix("frame0_luma_bias_"))
+        return ("rgb_bias", (value, value, value), frame_index)
+    if base.startswith("frame0_rgb_bias_"):
+        params = tuple(parse_signed_token(part) for part in base.removeprefix("frame0_rgb_bias_").split("_"))
+        if len(params) != 3:
+            raise ValueError(f"bad RGB compact selector mode {mode_id!r}")
+        return ("rgb_bias", params, frame_index)
+    if base.startswith("frame0_blue_chroma_amp_"):
+        return ("blue_chroma", (int(base.removeprefix("frame0_blue_chroma_amp_")),), frame_index)
+    if base.startswith("frame0_roll_dx"):
+        suffix = base.removeprefix("frame0_roll_dx")
+        dx_token, dy_token = suffix.split("_dy", 1)
+        return ("roll", (int(dx_token), int(dy_token)), frame_index)
+    raise ValueError(f"unsupported static compact selector mode {mode_id!r}")
+
+
+def unpack_fec6_fixed_huffman_codes(payload: bytes, *, n_pairs: int) -> list[int]:
+    codes: list[int] = []
+    prefix = ""
+    bit_pos = 0
+    max_bits = len(payload) * 8
+    while len(codes) < n_pairs:
+        if bit_pos >= max_bits:
+            raise ValueError("FEC6 compact selector bitstream truncated")
+        bit = (payload[bit_pos // 8] >> (7 - (bit_pos % 8))) & 1
+        bit_pos += 1
+        prefix += "1" if bit else "0"
+        code = FEC6_FIXED_K16_DECODE.get(prefix)
+        if code is not None:
+            codes.append(int(code))
+            prefix = ""
+            continue
+        if len(prefix) > 8:
+            raise ValueError("FEC6 compact selector contains invalid prefix code")
+    if prefix:
+        raise ValueError("FEC6 compact selector ended mid-symbol")
+    for trailing in range(bit_pos, max_bits):
+        if (payload[trailing // 8] >> (7 - (trailing % 8))) & 1:
+            raise ValueError("FEC6 compact selector has non-zero padding bits")
+    return codes
+
+
+def unpack_fec6_selector(selector_payload: bytes) -> tuple[list[int], tuple[tuple[str, tuple[int, ...], int], ...]]:
+    if selector_payload[:4] != b"FEC6":
+        raise ValueError(f"selector magic mismatch: {selector_payload[:4]!r}")
+    n_pairs = struct.unpack_from("<H", selector_payload, 4)[0]
+    codes = unpack_fec6_fixed_huffman_codes(selector_payload[6:], n_pairs=n_pairs)
+    specs = tuple(mode_spec_from_static_mode_id(mode_id) for mode_id in FEC6_FIXED_K16_MODE_IDS)
+    return codes, specs
+
+
+def apply_dynamic_mode(frame_chw: torch.Tensor, spec: tuple[str, tuple[int, ...], int]) -> torch.Tensor:
+    family, params, _frame_index = spec
+    if family == "identity":
+        return frame_chw
+    out = frame_chw.clone()
+    if family == "rgb_bias":
+        delta = torch.tensor(params, dtype=out.dtype, device=out.device).view(3, 1, 1)
+        return out + delta
+    if family == "blue_chroma":
+        amp = float(params[0])
+        _channels, height, width = out.shape
+        tile = selector_blue_tile(height, width, device=out.device, dtype=out.dtype)
+        out[0].add_(tile * amp)
+        out[2].sub_(tile * amp)
+        return out
+    if family == "roll":
+        dx, dy = int(params[0]), int(params[1])
+        return torch.roll(out, shifts=(dy, dx), dims=(1, 2))
+    raise ValueError(f"unsupported compact selector family {family!r}")
+
+
+def apply_compact_selector_to_frames(
+    frames_bchw: torch.Tensor,
+    selector_codes: list[int],
+    selector_specs: tuple[tuple[str, tuple[int, ...], int], ...],
+    *,
+    pair_start: int,
+) -> torch.Tensor:
+    """Verbatim fec6 compact-selector apply: transforms AFTER bias+clamp+round,
+    then one final batch clamp_/round_."""
+    if frames_bchw.shape[0] % 2 != 0:
+        raise ValueError("compact selector expects complete frame pairs")
+    out = frames_bchw.clone()
+    n_pairs = frames_bchw.shape[0] // 2
+    for offset in range(n_pairs):
+        pair_index = pair_start + offset
+        if pair_index >= len(selector_codes):
+            raise ValueError(f"selector has {len(selector_codes)} entries; missing pair {pair_index}")
+        spec = selector_specs[int(selector_codes[pair_index])]
+        family, _params, frame_index = spec
+        if family == "identity":
+            continue
+        frame_offset = offset * 2 + int(frame_index)
+        out[frame_offset] = apply_dynamic_mode(out[frame_offset], spec)
+    return out.clamp_(0.0, 255.0).round_()
+
+
+def parse_member(member_bytes: bytes):
+    """ctx container + trailing verbatim sidecar -> (state_dict, latents,
+    selector codes, selector specs)."""
+    if len(member_bytes) <= SIDECAR_HUFF_ENUM_LEN + 7:
+        raise ValueError("member too short")
+    sidecar = member_bytes[-SIDECAR_HUFF_ENUM_LEN:]
+    container = member_bytes[:-SIDECAR_HUFF_ENUM_LEN]
+    streams, latent_raw, selector_payload = codec_ctx.unpack_container(container)
+    decoder_sd = decode_decoder_compact(b"".join(streams))
+    latents = apply_latent_sidecar(decode_latents_compact(latent_raw), sidecar)
+    selector_codes, selector_specs = unpack_fec6_selector(selector_payload)
+    return decoder_sd, latents, selector_codes, selector_specs
+
+
+def inflate(src_bin: str, dst_raw: str) -> int:
+    decoder_sd, latents, selector_codes, selector_specs = parse_member(Path(src_bin).read_bytes())
+
+    device = torch.device("cpu")  # pinned: CPU is the leaderboard axis and the byte-stability reference
+    decoder = HNeRVDecoder(
+        latent_dim=LATENT_DIM,
+        base_channels=BASE_CHANNELS,
+        eval_size=EVAL_SIZE,
+    ).to(device)
+    decoder.load_state_dict(decoder_sd)
+    decoder.eval()
+
+    latents = latents.to(device)
+    n_pairs = N_PAIRS
+    if len(selector_codes) != n_pairs:
+        raise SystemExit(f"selector has {len(selector_codes)} pairs; archive requires exactly {n_pairs}")
+    eval_h, eval_w = EVAL_SIZE
+
+    n = 0
+    with torch.inference_mode(), open(dst_raw, "wb") as fout:
+        for i in range(0, n_pairs, 16):
+            j = min(i + 16, n_pairs)
+            batch = j - i
+            decoded = decoder(latents[i:j])
+            flat = decoded.reshape(batch * 2, 3, eval_h, eval_w)
+            up = F.interpolate(flat, size=(CAMERA_H, CAMERA_W), mode="bicubic", align_corners=False)
+            up = up.reshape(batch, 2, 3, CAMERA_H, CAMERA_W)
+            up[:, 0, 0].sub_(1.0)
+            up[:, 0, 2].sub_(1.0)
+            up[:, 1, 1].sub_(1.0)
+            rounded = up.reshape(batch * 2, 3, CAMERA_H, CAMERA_W).clamp(0, 255).round()
+            rounded = apply_compact_selector_to_frames(
+                rounded,
+                selector_codes,
+                selector_specs,
+                pair_start=i,
+            )
+            frames = rounded.to(torch.uint8).permute(0, 2, 3, 1).cpu().numpy()
+            fout.write(frames.tobytes())
+            n += batch * 2
+
+    print(f"saved {n} frames")
+    return n
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("Usage: python inflate.py <src.bin> <dst.raw>")
+    inflate(sys.argv[1], sys.argv[2])

--- a/submissions/rhnerv_comma/inflate.sh
+++ b/submissions/rhnerv_comma/inflate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+if [ -n "${PACT_PYTHON_BIN:-}" ]; then
+  PYTHON_BIN="$PACT_PYTHON_BIN"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN=python
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=python3
+else
+  echo "ERROR: neither python nor python3 is available" >&2
+  exit 127
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  BASE="${line%.*}"
+  SRC="${DATA_DIR}/x"
+  if [ ! -f "$SRC" ]; then
+    SRC="${DATA_DIR}/${BASE}.bin"
+  fi
+  DST="${OUTPUT_DIR}/${BASE}.raw"
+
+  [ ! -f "$SRC" ] && echo "ERROR: ${SRC} not found" >&2 && exit 1
+
+  printf "Inflating %s ... " "$line"
+  "$PYTHON_BIN" "$HERE/inflate.py" "$SRC" "$DST"
+done < "$FILE_LIST"

--- a/submissions/rhnerv_comma/model.py
+++ b/submissions/rhnerv_comma/model.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+"""HNeRV-style decoder: 229K params, single-video memorization.
+
+Per-frame-pair latent (28-d) -> 6 upsample stages -> 384x512 RGB pair.
+
+Each stage: Conv(in, out*4, 3x3) + PixelShuffle(2) + bilinear-skip + sin().
+Final: dilated-conv refine residual + sigmoid RGB heads (separate frame 0 and 1).
+
+Byte-identical to the HNeRV decoder published in PR #95 by @AaronLeslie138
+(https://github.com/commaai/comma_video_compression_challenge/pull/95).
+Reused unmodified; this submission performed no new training of the decoder.
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class HNeRVDecoder(nn.Module):
+    def __init__(self, latent_dim=28, base_channels=36, eval_size=(384, 512)):
+        super().__init__()
+        self.eval_size = eval_size
+        self.base_h, self.base_w = 6, 8
+        C = base_channels
+
+        # 7 stages from 6x8 to 384x512; channel taper matches HNeRV paper
+        self.channels = [C, C, C, int(C * 0.75), int(C * 0.58), int(C * 0.5), int(C * 0.5)]
+
+        self.stem = nn.Linear(latent_dim, self.channels[0] * self.base_h * self.base_w)
+
+        self.blocks = nn.ModuleList()
+        self.skips = nn.ModuleList()
+        for i in range(6):
+            in_ch = self.channels[i]
+            out_ch = self.channels[i + 1]
+            self.blocks.append(nn.Conv2d(in_ch, out_ch * 4, 3, padding=1))
+            self.skips.append(nn.Conv2d(in_ch, out_ch, 1) if in_ch != out_ch else nn.Identity())
+        self.ps = nn.PixelShuffle(2)
+
+        final_ch = self.channels[-1]
+        self.refine = nn.Sequential(
+            nn.Conv2d(final_ch, final_ch // 2, 3, padding=2, dilation=2),
+            nn.Conv2d(final_ch // 2, final_ch, 3, padding=1),
+        )
+        self.rgb_0 = nn.Conv2d(final_ch, 3, 3, padding=1)
+        self.rgb_1 = nn.Conv2d(final_ch, 3, 3, padding=1)
+
+    def forward(self, z):
+        B = z.shape[0]
+        x = self.stem(z).view(B, self.channels[0], self.base_h, self.base_w)
+        x = torch.sin(x)
+        for block, skip in zip(self.blocks, self.skips):
+            identity = F.interpolate(x, scale_factor=2, mode='bilinear', align_corners=False)
+            identity = skip(identity)
+            x = self.ps(block(x))
+            x = torch.sin(x + identity)
+        x = x + 0.1 * torch.sin(self.refine(x))
+        f0 = torch.sigmoid(self.rgb_0(x)) * 255.0
+        f1 = torch.sigmoid(self.rgb_1(x)) * 255.0
+        return torch.stack([f0, f1], dim=1)


### PR DESCRIPTION
## rhnerv_comma

**Submission name:** `rhnerv_comma` (matches `submissions/rhnerv_comma/`)

**archive.zip (177,136 bytes):**
https://github.com/mattneel/comma_video_compression_challenge/releases/download/rhnerv-comma-v1/archive.zip
SHA-256 `dd4f3899b91f5b59df90b4bf4fc4d903099a286548339f5f65ff91e4b8146aa4` — `curl -L` verified by a fork CI run of the eval workflow ([run](https://github.com/mattneel/comma_video_compression_challenge/actions/runs/27256209011)).

**report.txt** (from that ubuntu-latest eval run):
```
=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.00002943
  Average SegNet Distortion: 0.00056023
  Submission file size: 177,136 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.00471790
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 0.19
```
Full precision: 100·0.00056023 + √(10·0.00002943) + 25·0.00471790 = **0.191126** (current #1, PR #110: 0.192045).

**Does your submission require GPU for evaluation (inflation)?** No — decode is pinned to CPU, < 3 minutes on 4 cores.

**Did you include the compression script?** Yes — `compress.sh` rebuilds `archive.zip` byte-for-byte from the SHA-pinned PR #101/#110 release archives (deterministic, no training).

**Is your submission competitive or innovative?** Competitive (and hopefully a little innovative on the coding side): the decoded video is **byte-identical to PR #110's** — same SegNet/PoseNet distortions to all printed decimals — with the payload losslessly re-coded:

- the 7 Brotli streams over the INT8 decoder weights are replaced by **per-tensor adaptive range coding** (constriction ANS, geometric-primed priors, 2 B/model headers): −1,060 B. The weight byte-streams turn out to be memoryless given tensor identity — Brotli q11 sits ~950 B above per-tensor order-0 adaptive cost, and every conditional context we tried (order-1, kernel-position, stored-axis neighbors, DeepCABAC-style binarization) loses.
- the raw-LZMA1 latent blob is replaced by **causal-prediction models** (per-dim AR(1) — the quantized latent codes have *negative* autocorrelation ≈ −0.45 — plus cross-dim predictors with integer-quantized LS coefficients, discrete-Gaussian residual coding): −317 B.
- the FEC6 selector is re-coded with adaptive AC (−1 B; it was already at entropy), the #101 latent-correction sidecar is kept verbatim (measured < 7 B from optimal), container framing −3 B.

Total: 178,517 → 177,136 bytes (−1,381). Decode adds ~0.2 s.

**Lineage and attribution** (see `THIRD_PARTY_NOTICES.md`): decoder weights/latents/sidecar content from PR #101 (@SajayR), reused information-identically and re-coded; selector content and inflate transform chain from PR #110 (@adpena); model architecture from PR #95 (@AaronLeslie138, MIT); channel-offset postprocess from PR #98 (@EthanYangTW). Thanks to all four — this submission is deliberately a pure entropy-coding delta on top of their work.

### 60-second repro
```bash
git clone https://github.com/commaai/comma_video_compression_challenge && cd comma_video_compression_challenge
git lfs pull && uv sync --group cpu
# fetch this PR's submission dir, then:
curl -L -o submissions/rhnerv_comma/archive.zip \
  https://github.com/mattneel/comma_video_compression_challenge/releases/download/rhnerv-comma-v1/archive.zip
uv run --group cpu bash evaluate.sh --device cpu --submission-dir ./submissions/rhnerv_comma
```
