### PR TITLE
submission: sai_x265_512_crf28

### DIFF
--- a/submissions/sai_x265_512_crf28/compress.sh
+++ b/submissions/sai_x265_512_crf28/compress.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PD="$(cd "${HERE}/../.." && pwd)"
+
+IN_DIR="${PD}/videos"
+VIDEO_NAMES_FILE="${PD}/public_test_video_names.txt"
+ARCHIVE_DIR="${HERE}/archive"
+JOBS="1"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in-dir|--in_dir) IN_DIR="${2%/}"; shift 2 ;;
+    --jobs) JOBS="$2"; shift 2 ;;
+    --video-names-file|--video_names_file) VIDEO_NAMES_FILE="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+rm -rf "$ARCHIVE_DIR"
+rm -f "${HERE}/archive.zip"
+mkdir -p "$ARCHIVE_DIR"
+
+export IN_DIR ARCHIVE_DIR
+
+cat "$VIDEO_NAMES_FILE" | xargs -P"$JOBS" -I{} bash -lc '
+  rel="$1"
+  [[ -z "$rel" ]] && exit 0
+
+  input_file="${IN_DIR}/${rel}"
+  base="${rel%.*}"
+  output_file="${ARCHIVE_DIR}/${base}.mkv"
+
+  echo "Encoding ${input_file} -> ${output_file}"
+
+  ffmpeg -nostdin -y -hide_banner -loglevel warning \
+    -r 20 -fflags +genpts -i "$input_file" \
+    -vf "hqdn3d=1.5:1.5:6:6,scale=512:384:flags=lanczos" \
+    -c:v libx265 -preset slow -crf 28 \
+    -g 60 \
+    -x265-params "keyint=60:min-keyint=30:bframes=4:log-level=warning" \
+    -r 20 "$output_file"
+' _ {}
+
+cd "$ARCHIVE_DIR"
+zip -r "${HERE}/archive.zip" .
+echo "Compressed to ${HERE}/archive.zip"

--- a/submissions/sai_x265_512_crf28/inflate.py
+++ b/submissions/sai_x265_512_crf28/inflate.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Inflate: decode compressed MKV → upscale to camera_size → sharpen → .raw
+#
+# Why sharpen after upscale?
+#   Bicubic upscaling from 512x384 to 1164x874 introduces slight blurring.
+#   The unsharp mask (x + k*(x - blur(x))) recovers edge contrast that
+#   PoseNet relies on for depth and motion estimation.
+#   k=3.0 means each edge pixel is amplified by 4x relative to its 5x5
+#   neighbourhood — strong but appropriate for the 2.27x upscale factor.
+import av, torch
+import torch.nn.functional as F
+from frame_utils import camera_size, yuv420_to_rgb
+
+
+def decode_and_resize_to_file(video_path: str, dst: str):
+  target_w, target_h = camera_size  # (1164, 874)
+  fmt = 'hevc' if video_path.endswith('.hevc') else None
+  container = av.open(video_path, format=fmt)
+  stream = container.streams.video[0]
+  n = 0
+  with open(dst, 'wb') as f:
+    for frame in container.decode(stream):
+      t = yuv420_to_rgb(frame)  # (H, W, 3) uint8
+      H, W, _ = t.shape
+      if H != target_h or W != target_w:
+        x = t.permute(2, 0, 1).unsqueeze(0).float()  # (1, C, H, W)
+        x = F.interpolate(x, size=(target_h, target_w), mode='bicubic', align_corners=False)
+        # Unsharp mask: recover edges blurred by the 2.27x bicubic upscale.
+        # reflect-pad avoids border darkening from zero-padding in avg_pool.
+        blur = F.avg_pool2d(F.pad(x, (2, 2, 2, 2), mode='reflect'), 5, stride=1)
+        x = (x + 3.0 * (x - blur)).clamp(0, 255)
+        t = x.squeeze(0).permute(1, 2, 0).round().to(torch.uint8)
+      f.write(t.contiguous().numpy().tobytes())
+      n += 1
+  container.close()
+  return n
+
+
+if __name__ == "__main__":
+  import sys
+  src, dst = sys.argv[1], sys.argv[2]
+  n = decode_and_resize_to_file(src, dst)
+  print(f"saved {n} frames")

--- a/submissions/sai_x265_512_crf28/inflate.sh
+++ b/submissions/sai_x265_512_crf28/inflate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Decodes each compressed .mkv, upscales to original camera_size (1164x874),
+# applies unsharp mask to recover edge detail lost in bicubic upscaling,
+# and writes a flat uint8 RGB binary (.raw) consumed by TensorVideoDataset.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+SUB_NAME="$(basename "$HERE")"
+
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  BASE="${line%.*}"
+  SRC="${DATA_DIR}/${BASE}.mkv"
+  DST="${OUTPUT_DIR}/${BASE}.raw"
+
+  [ ! -f "$SRC" ] && echo "ERROR: ${SRC} not found" >&2 && exit 1
+
+  printf "Decoding + resizing %s ... " "$line"
+  cd "$ROOT"
+  python3 -m "submissions.${SUB_NAME}.inflate" "$SRC" "$DST"
+done < "$FILE_LIST"


### PR DESCRIPTION
x265 slow CRF 28, 512x384 SegNet-aligned, keyint=60 with B-frames, hqdn3d denoise before encode, bicubic upscale + unsharp mask in inflate.

Local score on Mac M2 MPS: 2.99

# submission name:

sai_x265_512_crf28

# upload zipped `archive.zip`

https://drive.google.com/file/d/1bS0l9chmFAZE1Ys2D8N1eDGEg-mfTSXK/view?usp=sharing

# report.txt

```
=== Evaluation config ===
  batch_size: 16
  device: mps
  num_threads: 2
  prefetch_queue_depth: 4
  report: submissions/my_submission/report.txt
  seed: 1234
  submission_dir: submissions/my_submission
  uncompressed_dir: /Users/saitejareddy/comma_video_compression_challenge/videos
  video_names_file: /Users/saitejareddy/comma_video_compression_challenge/public_test_video_names.txt

=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.30524099
  Average SegNet Distortion: 0.00757646
  Submission file size: 734,777 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.01957031
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 2.99
```

# does your submission require gpu for evaluation (inflation)?

no

# did you include the compression script? and want it to be merged?

yes

# is this submission competitive or innovative? explain why

Not competitive with the top leaderboard submissions. This is a simple FFmpeg/x265-based improvement over the baseline. It uses inter-frame coding, B-frames, light denoising, SegNet-aligned 512x384 scaling, and post-upscale sharpening to reduce file size while keeping PoseNet and SegNet distortion lower than the baseline.

# additional comments

I tested CRF 29–32 and GOP 90, but those worsened the final score, mainly due to increased PoseNet distortion. The best local result was CRF 28 with GOP/keyint 60.
