### PR TITLE
svtav1_512_grain20

### DIFF
--- a/submissions/svtav1_512_grain20/inflate.py
+++ b/submissions/svtav1_512_grain20/inflate.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import av, torch
+import torch.nn.functional as F
+from frame_utils import camera_size, yuv420_to_rgb
+
+# Gaussian-like 9x9 unsharp kernel (binomial coefficients squared, normalized).
+# Used to sharpen frames after bicubic upsample back to camera_size, recovering
+# high-frequency detail attenuated by the lanczos downscale + AV1 quantization.
+UNSHARP_KERNEL = torch.tensor([
+  [1., 8., 28., 56., 70., 56., 28., 8., 1.],
+  [8., 64., 224., 448., 560., 448., 224., 64., 8.],
+  [28., 224., 784., 1568., 1960., 1568., 784., 224., 28.],
+  [56., 448., 1568., 3136., 3920., 3136., 1568., 448., 56.],
+  [70., 560., 1960., 3920., 4900., 3920., 1960., 560., 70.],
+  [56., 448., 1568., 3136., 3920., 3136., 1568., 448., 56.],
+  [28., 224., 784., 1568., 1960., 1568., 784., 224., 28.],
+  [8., 64., 224., 448., 560., 448., 224., 64., 8.],
+  [1., 8., 28., 56., 70., 56., 28., 8., 1.],
+], dtype=torch.float32) / 65536.0
+
+UNSHARP_AMOUNT = 0.85
+
+
+def decode_and_resize_to_file(video_path: str, dst: str):
+  target_w, target_h = camera_size
+  fmt = 'hevc' if video_path.endswith('.hevc') else None
+  container = av.open(video_path, format=fmt)
+  stream = container.streams.video[0]
+  n = 0
+  with open(dst, 'wb') as f:
+    for frame in container.decode(stream):
+      t = yuv420_to_rgb(frame)  # (H, W, 3) uint8
+      H, W, _ = t.shape
+      if H != target_h or W != target_w:
+        x = t.permute(2, 0, 1).unsqueeze(0).float()  # (1, C, H, W)
+        x = F.interpolate(x, size=(target_h, target_w), mode='bicubic', align_corners=False)
+        kernel = UNSHARP_KERNEL.to(device=x.device).expand(3, 1, 9, 9)
+        blur = F.conv2d(x, kernel, padding=4, groups=3)
+        x = x + UNSHARP_AMOUNT * (x - blur)
+        t = x.clamp(0, 255).squeeze(0).permute(1, 2, 0).round().to(torch.uint8)
+      f.write(t.contiguous().numpy().tobytes())
+      n += 1
+  container.close()
+  return n
+
+
+if __name__ == "__main__":
+  import sys
+  src, dst = sys.argv[1], sys.argv[2]
+  n = decode_and_resize_to_file(src, dst)
+  print(f"saved {n} frames")

--- a/submissions/svtav1_512_grain20/inflate.sh
+++ b/submissions/svtav1_512_grain20/inflate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Must produce a raw video file at `<output_dir>/<base_name>.raw`.
+# A `.raw` file is a flat binary dump of uint8 RGB frames with shape `(N, H, W, 3)`
+# where N is the number of frames, H and W match the original video dimensions, no header.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+SUB_NAME="$(basename "$HERE")"
+
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  BASE="${line%.*}"
+  SRC="${DATA_DIR}/${BASE}.mkv"
+  DST="${OUTPUT_DIR}/${BASE}.raw"
+
+  [ ! -f "$SRC" ] && echo "ERROR: ${SRC} not found" >&2 && exit 1
+
+  printf "Decoding + resizing %s ... " "$line"
+  cd "$ROOT"
+  python -m "submissions.${SUB_NAME}.inflate" "$SRC" "$DST"
+done < "$FILE_LIST"


### PR DESCRIPTION
# submission name:
svtav1_512_grain20

# upload zipped `archive.zip`
https://github.com/shaina-k02/comma_video_compression_challenge/releases/download/my-submission-v1/archive.zip

(`curl -L` verified; 715,585 bytes, contains `0.mkv`)

# report.txt
```
=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.11481448
  Average SegNet Distortion: 0.00616225
  Submission file size: 715,585 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.01905915
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 2.16
```
(measured locally with `--device mps`; official CUDA/CPU eval may differ slightly)

# does your submission require gpu for evaluation (inflation)?
No.
Inflation is ffmpeg decode + a small CPU torch interpolate/unsharp, runs fine on `ubuntu-latest`.

# did you include the compression script? and want it to be merged?
No. 

# is this submission competitive or innovative? explain why
Its value is a tidy, reproducible tuning of two effects that the metrics reward:
- **Encode exactly at 512×384** (scale 0.44). Both SegNet and PoseNet downscale every frame to 512×384, so encoding at that resolution avoids wasting bits that get thrown away, measured strictly better than 0.45.
- **film-grain=20 is the dominant PoseNet lever.** The real sensor grain is what PoseNet keys on for apparent motion; downscale + AV1 strips it, pushing PoseNet out-of-distribution (pose distortion 0.40 with grain off vs 0.11 with grain on). Level 20 matched the source grain best.
