### PR TITLE
Add video compression submission

### DIFF
--- a/submissions/final_best/compress.py
+++ b/submissions/final_best/compress.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import zipfile
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+HERE = os.path.dirname(__file__)
+
+in_video = os.path.join(ROOT, "videos", "0.mkv")
+archive_dir = os.path.join(HERE, "archive")
+out_video = os.path.join(archive_dir, "0.mkv")
+archive_zip = os.path.join(HERE, "archive.zip")
+
+os.system(f"rm -rf {archive_dir}")
+os.makedirs(archive_dir, exist_ok=True)
+
+cmd = [
+    "ffmpeg", "-nostdin", "-y",
+    "-hide_banner", "-loglevel", "warning",
+    "-r", "20",
+    "-fflags", "+genpts",
+    "-i", in_video,
+    "-vf", "scale=trunc(iw*0.45/2)*2:trunc(ih*0.45/2)*2:flags=lanczos",
+    "-c:v", "libx265",
+    "-preset", "ultrafast",
+    "-crf", "29",
+    "-g", "60",
+    "-bf", "0",
+    "-x265-params", "keyint=60:min-keyint=60:scenecut=0:frame-threads=4:log-level=warning",
+    "-r", "20",
+    out_video,
+]
+
+subprocess.run(cmd, check=True)
+
+with zipfile.ZipFile(archive_zip, "w", compression=zipfile.ZIP_DEFLATED) as z:
+    z.write(out_video, "0.mkv")
+
+print("saved", archive_zip)

--- a/submissions/final_best/compress.sh
+++ b/submissions/final_best/compress.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python "$(dirname "$0")/compress.py"

--- a/submissions/final_best/inflate.py
+++ b/submissions/final_best/inflate.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import av, torch
+import torch.nn.functional as F
+from frame_utils import camera_size, yuv420_to_rgb
+
+
+def decode_and_resize_to_file(video_path: str, dst: str):
+  target_w, target_h = camera_size
+  fmt = 'hevc' if video_path.endswith('.hevc') else None
+  container = av.open(video_path, format=fmt)
+  stream = container.streams.video[0]
+  n = 0
+  with open(dst, 'wb') as f:
+    for frame in container.decode(stream):
+      t = yuv420_to_rgb(frame)  # (H, W, 3)
+      H, W, _ = t.shape
+      if H != target_h or W != target_w:
+        x = t.permute(2, 0, 1).unsqueeze(0).float()  # (1, C, H, W)
+        x = F.interpolate(x, size=(target_h, target_w), mode='bicubic', align_corners=False)
+        t = x.clamp(0, 255).squeeze(0).permute(1, 2, 0).round().to(torch.uint8)
+      f.write(t.contiguous().numpy().tobytes())
+      n += 1
+  container.close()
+  return n
+
+
+if __name__ == "__main__":
+  import sys
+  src, dst = sys.argv[1], sys.argv[2]
+  n = decode_and_resize_to_file(src, dst)
+  print(f"saved {n} frames")

--- a/submissions/final_best/inflate.sh
+++ b/submissions/final_best/inflate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Must produce a raw video file at `<output_dir>/<base_name>.raw`.
+# A `.raw` file is a flat binary dump of uint8 RGB frames with shape `(N, H, W, 3)`
+# where N is the number of frames, H and W match the original video dimensions, no header.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+SUB_NAME="$(basename "$HERE")"
+
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  BASE="${line%.*}"
+  SRC="${DATA_DIR}/${BASE}.mkv"
+  DST="${OUTPUT_DIR}/${BASE}.raw"
+
+  [ ! -f "$SRC" ] && echo "ERROR: ${SRC} not found" >&2 && exit 1
+
+  printf "Decoding + resizing %s ... " "$line"
+  cd "$ROOT"
+  python -m "submissions.${SUB_NAME}.inflate" "$SRC" "$DST"
+done < "$FILE_LIST"


### PR DESCRIPTION
# submission name:
final_best

# upload zipped `archive.zip`
Attached `archive.zip` to this Pull Request.
[archive.zip](https://github.com/user-attachments/files/29454673/archive.zip)


# report.txt
```
[archive.zip](https://github.com/user-attachments/files/29454601/archive.zip)

=== Evaluation results over 600 samples ===
Average PoseNet Distortion: 0.34403270
Average SegNet Distortion: 0.00976947
Submission file size: 793,773 bytes
Original uncompressed size: 37,545,489 bytes
Compression Rate: 0.02114163
Final score: 3.36
```

# does your submission require gpu for evaluation (inflation)?
No

# did you include the compression script? and want it to be merged?
Yes

# is this submission competitive or innovative? explain why
This submission improves the official baseline by tuning the H.265 encoding configuration. The approach uses temporal compression (GOP/keyint 60), CRF 29, scale factor 0.45, and ZIP_DEFLATED packaging. These changes improved the local evaluation score from approximately 4.46 to 3.36.

# additional comments
The submission includes the compression and inflation scripts required to reproduce the results. Evaluation does not require a GPU. The solution is based on systematic exploration of FFmpeg/libx265 parameters while maintaining compatibility with the official evaluation pipeline.
