### PR TITLE
hnerv_qlp

### DIFF
--- a/submissions/hnerv_qlp/.gitignore
+++ b/submissions/hnerv_qlp/.gitignore
@@ -1,0 +1,6 @@
+work/
+__pycache__/
+ckpts/
+inflated/
+*.raw
+encoder/__pycache__/

--- a/submissions/hnerv_qlp/LICENSE
+++ b/submissions/hnerv_qlp/LICENSE
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright (c) 2026 Manthan Sumbhe
+Portions copyright (c) their original authors: PR #95 (Aaron Leslie),
+PR #98 (Ethan Yang), PR #101 (SajayR), PR #110 (Alejandro Peña),
+PR #112 (Matt Neel) — see THIRD_PARTY_NOTICES.md for the full lineage.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/submissions/hnerv_qlp/README.md
+++ b/submissions/hnerv_qlp/README.md
@@ -1,0 +1,92 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# hnerv_qlp — quantization-aware latent polish
+
+Takes the current frontier payload (PR
+[#112](https://github.com/commaai/comma_video_compression_challenge/pull/112)
+`rhnerv_comma`, a lossless re-code of PR #110 / #101 / #98 / #95) and performs
+one new step: with the decoder **frozen**, each frame pair's 28-dim latent is
+re-optimized by gradient descent directly against the SegNet/PoseNet distortion,
+through the exact inflate chain. The re-optimized latents then match the #1's
+distortion **without** its 607-byte latent-correction sidecar — so the sidecar
+is dropped, and the archive is 611 bytes smaller.
+
+No decoder training. The decoder weights and the FEC6 selector are reused
+bit-for-bit; only the latent codes change (and the sidecar is removed).
+
+## Result
+
+| | SegNet dist | PoseNet dist | bytes | **score (CPU)** |
+|---|---|---|---|---|
+| #1 `rhnerv_comma` | `0.00056023` | `0.00002943` | `177,136` | `0.191126` |
+| **hnerv_qlp** | `0.00056085` | `0.00003000` | `176,525` | **`0.190946`** |
+
+Margin **−0.000180** vs the official #1. Distortion is essentially unchanged
+(the polish recovers what dropping the sidecar would otherwise cost); the win is
+the −611-byte rate saving. Local CPU eval reproduces the #1's published metrics
+to ~1e-5, so the margin (~18× that) is real. Score is reported on the CPU
+(leaderboard) axis via `evaluate.py --device cpu`.
+
+## Archive identity
+
+**Download:** <https://github.com/Bucky789/comma_video_compression_challenge/releases/download/hnerv-qlp-v1/archive.zip>
+
+| Field | Value |
+|---|---|
+| Archive bytes | `176,525` |
+| Archive SHA-256 | `ebd513903bd598b4d73d699a11c89600bd11747f27aab26737e518096675b813` |
+| ZIP members | 1 (`x`, `ZIP_STORED`, 176,425 B) |
+| Member layout | ctx container only (7-B header + decoder 161,104 + latents 15,066 + selector 248); **no sidecar** |
+| Inflate deps | `torch`, `numpy`, `constriction` |
+| Inflate GPU required | no (device pinned to CPU) |
+
+## The new idea
+
+PR #101's sidecar already hinted at this: it searched **one** latent dimension
+per pair over a small fixed step table and was worth ≈ −0.001. `hnerv_qlp`
+generalizes that to **continuous gradient descent over all 28 dimensions** of
+every pair's latent, against the frozen quantized decoder. Two details make it
+land on the real leaderboard axis rather than a GPU proxy:
+
+1. **fp32 evaluation and selection.** The SegNet distortion is a discrete
+   argmax; fp16 and fp32 disagree on borderline pixels. Selecting latents on an
+   fp16 scorer overfits GPU noise and regresses on the CPU axis (an earlier
+   fp16-selected build scored `0.191955`). Evaluation and per-pair selection
+   run in fp32; training stays fp16 for speed (gradients are smooth).
+2. **Exact-chain optimization.** The polish forward pass replicates the inflate
+   chain bit-for-bit — bicubic 874×1164, the #98 channel biases, clamp/round,
+   the FEC6 per-pair selector — so the gradient targets the scored pixels.
+
+## Inflate
+
+```bash
+unzip archive.zip -d /tmp/data      # -> /tmp/data/x
+echo "0.mkv" > /tmp/list.txt
+bash inflate.sh /tmp/data /tmp/out /tmp/list.txt
+```
+
+## Reproduce the encode
+
+Offline; needs a CUDA GPU and the PR #101 / #110 archives (fetched from their
+releases, SHA-256-verified, never redistributed):
+
+```bash
+# 1. extract the frozen decoder + latents + selector from the #110 payload
+python encoder/extract_payload.py
+# 2. quantization-aware latent polish (fp32 eval/selection, ~1 h on an RTX 4060)
+python encoder/polish.py --epochs 150 --lr 5e-4 --batch 3 --eval-every 10
+# 3. pack the polished latents into the ctx container (decoder/selector verbatim)
+python encoder/pack.py --codes work/pilot2/best_codes.pt --out archive.zip
+```
+
+See `THIRD_PARTY_NOTICES.md` for the full lineage (PRs #95/#98/#101/#110/#112).
+
+## Files
+
+| Path | Role |
+|---|---|
+| `archive.zip` | The submission. |
+| `inflate.sh`, `inflate.py` | Contest-runtime decoder (CPU, no sidecar). |
+| `codec.py`, `codec_ctx.py`, `frame_selector.py`, `model.py` | Vendored decode runtime (PR #112 / #110 / #95). |
+| `encoder/` | Offline extract → polish → pack pipeline (new). |
+| `LICENSE`, `THIRD_PARTY_NOTICES.md` | MIT + upstream attribution. |

--- a/submissions/hnerv_qlp/THIRD_PARTY_NOTICES.md
+++ b/submissions/hnerv_qlp/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,99 @@
+<!-- SPDX-License-Identifier: MIT -->
+# Third-Party Notices
+
+This submission builds directly on prior work in the contest repository, all
+reused under the repository's MIT license. It takes the current-frontier
+payload (PR #112, itself a lossless re-code of PR #110 over PR #101 over
+PR #98/#95) and performs one new step: a **quantization-aware gradient polish
+of the per-pair latents** against the frozen decoder, followed by re-encoding.
+The decoder weights and the frame selector are reused information-identically;
+only the latent codes change, and the 607-byte latent sidecar is dropped.
+
+## PR #95 — HNeRV decoder
+
+- **Author**: @AaronLeslie138
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/95
+- **License**: MIT (inherited from the contest repository)
+- **What this submission uses**: the HNeRV decoder architecture and its
+  trained weights (229K params, per-pair latent → 6 upsample stages → 384×512
+  RGB pair). `model.py` is a verbatim copy. The weights are reused **byte-for-
+  byte** — the polish freezes them and never updates a single decoder
+  parameter. No decoder training was performed.
+
+## PR #98 — finetuned weights + channel-bias inflate
+
+- **Author**: @EthanYangTW
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/98
+- **License**: MIT (inherited from the contest repository)
+- **What this submission uses**: the frozen decoder weights are #98's
+  finetune of #95, and the per-pair channel-bias step in `inflate.py`
+  (frame0 R−1, frame0 B−1, frame1 G−1, before clamp/round) originates in #98.
+  This bias is replicated inside the polish forward pass so the latents are
+  optimized against the exact inflate math.
+
+## PR #101 — `hnerv_ft_microcodec` payload substrate
+
+- **Author**: @SajayR
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/101
+- **License**: MIT (inherited from the contest repository)
+- **What this submission uses**: the decoder weight streams (reused
+  bit-exactly) and the **latent quantization grammar** — per-dim fp16
+  min/scale grid + dim-major temporal-delta uint8 codes. Our polished latents
+  are re-encoded into this exact grammar (`encoder/latent_codec.py` is the
+  inverse of #101's `decode_latents_compact`, verified byte-exact on the
+  original payload). `codec.py` is #101's decode logic as published in-tree by
+  #110. **Not used**: #101's 607-byte 1-dim latent-correction sidecar — the
+  polish optimizes all 28 dims per pair and subsumes it. The offline encoder
+  fetches #101's archive from its release (SHA-256
+  `b83bf3488625dbd73adeddff91712994197ab53098e578e91327a0c6e49efb3e`) and
+  never redistributes it.
+
+## PR #110 — `hnerv_fec6_fixed_huffman_k16` selector + inflate chain
+
+- **Author**: @adpena
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/110
+- **License**: MIT (sole-author Alejandro Peña, per its in-tree LICENSE)
+- **What this submission uses**: the FEC6 K=16 per-pair selector — its 249-byte
+  wire payload is reused **bit-exactly** — and the complete inflate transform
+  chain (batching, bicubic upsample, clamp/round ordering, per-pair selector
+  applied after bias+clamp+round then a final batch clamp/round). Both are
+  also replicated inside the polish forward pass so the latents are optimized
+  against the selector-transformed, scored pixels. `frame_selector.py` is a
+  verbatim copy; `inflate.py` is derived from fec6's (selector decode +
+  transform apply verbatim; container parse swapped for #112's; sidecar
+  removed). The encoder fetches #110's archive from its release (SHA-256
+  `6bae0201fb082457a02c69565531aba4c5942669c384fdc48e7d554f7b893fcf`) and
+  never redistributes it.
+
+## PR #112 — `rhnerv_comma` context-model container
+
+- **Author**: @mattneel (Matt Neel)
+- **PR**: https://github.com/commaai/comma_video_compression_challenge/pull/112
+- **License**: MIT (inherited from the contest repository)
+- **What this submission uses**: the context-modeled range-coder container
+  (`codec_ctx.py`, verbatim) that carries the decoder / latent / selector
+  sections, and the member/inflate scaffolding. We re-encode the **new**
+  polished latent section through the same `encode_latent_section`, keep the
+  decoder and selector sections byte-identical to #112's, and drop the trailing
+  sidecar. `inflate.py` and `codec.py` are #112's with the sidecar path
+  removed.
+
+## Open-source dependencies
+
+- **constriction** (https://github.com/bamler-lab/constriction, MIT/Apache-2.0
+  /BSL) — range coding primitives, used at both encode and inflate time.
+- **PyTorch** (BSD-3) — the frozen decoder and scorer networks (encode-time
+  polish) and the decoder (inflate time).
+- **Brotli** (`brotli` PyPI, MIT) and **raw LZMA1** (`lzma` stdlib) — used at
+  **encode time only**, to unwrap #101's source streams before re-coding. The
+  inflate path uses neither.
+
+## This submission's new contribution
+
+Quantization-aware latent polish: with the decoder frozen, each frame pair's
+28-dim latent is optimized by gradient descent (straight-through estimator on
+the #101 uint8 grid) directly against the SegNet/PoseNet distortion through the
+exact #110/#112 inflate chain. This is a strict generalization of #101's
+sidecar (which searched 1 dim × a fixed step table per pair) to continuous
+joint optimization over all 28 dims. `encoder/polish.py`, `encoder/pack.py`,
+`encoder/extract_payload.py`, `encoder/latent_codec.py` are new.

--- a/submissions/hnerv_qlp/archive.zip
+++ b/submissions/hnerv_qlp/archive.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebd513903bd598b4d73d699a11c89600bd11747f27aab26737e518096675b813
+size 176525

--- a/submissions/hnerv_qlp/codec.py
+++ b/submissions/hnerv_qlp/codec.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MIT
+"""Inflater-side codec for the PR #101 HNeRV-microcodec payload, raw-stream
+variant.
+
+Ported from `submissions/hnerv_fec6_fixed_huffman_k16/src/codec.py` (PR #110,
+@adpena, MIT), which itself reuses PR #101's (@SajayR) decode grammar. The
+ONLY functional change vs the fec6 original: the entropy-coding layer has been
+swapped out. `decode_decoder_compact` takes the RAW concatenated decoder
+stream bytes directly (already entropy-decoded by `codec_ctx`) instead of a
+Brotli blob, and `decode_latents_compact` takes the raw latent payload
+directly instead of an LZMA blob. Everything downstream of the entropy layer
+-- storage order, conv4 storage permutations, byte maps, scale handling,
+latent delta/cumsum reconstruction, dim reordering, fp32 math -- is verbatim
+fec6/#101, so the reconstructed tensors are bit-identical.
+
+All schema constants live in code (uncounted by the rate metric); the
+archive carries only video-specific payload bytes.
+"""
+import io
+
+import numpy as np
+import torch
+
+from model import HNeRVDecoder
+
+
+N_PAIRS = 600
+LATENT_DIM = 28
+BASE_CHANNELS = 36
+EVAL_SIZE = (384, 512)
+DECODER_RAW_LEN = 229_014   # sum of the 7 raw decoder streams
+LATENT_RAW_LEN = 16_912     # 2*2*28 fp16 header + 600*28 codes
+
+DECODER_STORAGE_ORDER = (
+    14, 22, 7, 6, 19, 10, 25, 4, 20, 9, 12, 15, 5, 11,
+    18, 1, 21, 3, 27, 13, 2, 26, 24, 17, 16, 23, 8, 0,
+)
+DECODER_STREAM_ENDS = (1, 2, 22, 23, 26, 27, 28)
+
+CONV4_STORAGE_PERMS = {
+    2: (3, 0, 2, 1),
+    4: (3, 0, 2, 1),
+    6: (0, 1, 2, 3),
+    8: (3, 0, 1, 2),
+    10: (3, 0, 2, 1),
+    12: (3, 0, 1, 2),
+    14: (1, 0, 2, 3),
+    16: (3, 0, 2, 1),
+    18: (1, 0, 2, 3),
+    20: (0, 3, 2, 1),
+    22: (0, 3, 2, 1),
+    24: (0, 2, 3, 1),
+    26: (0, 1, 3, 2),
+}
+CONV4_INVERSE_PERMS = {
+    idx: tuple(np.argsort(perm)) for idx, perm in CONV4_STORAGE_PERMS.items()
+}
+
+DECODER_BYTE_MAPS = {
+    9: "negzig",
+    14: "negzig",
+    20: "twos",
+    27: "off",
+}
+
+LATENT_DIM_ORDER = (
+    26, 0, 17, 15, 10, 24, 20, 12, 14, 21, 22, 18, 4, 11,
+    3, 7, 16, 2, 6, 8, 19, 23, 5, 9, 1, 13, 27, 25,
+)
+
+
+def zigzag_decode_u8(arr_u8):
+    """Map unsigned zigzag symbols back to signed int8 residuals."""
+    arr = arr_u8.astype(np.int32)
+    return np.where(arr % 2 == 0, arr // 2, -(arr // 2) - 1).astype(np.int8)
+
+
+def decode_mapped_u8(arr_u8, byte_map):
+    """Decode one stored uint8 tensor stream using its declared byte map."""
+    if byte_map == "zig":
+        return zigzag_decode_u8(arr_u8)
+    if byte_map == "negzig":
+        return (-zigzag_decode_u8(arr_u8).astype(np.int16)).astype(np.int8)
+    if byte_map == "off":
+        return (arr_u8.astype(np.int16) - 128).astype(np.int8)
+    if byte_map == "twos":
+        return arr_u8.view(np.int8)
+    raise ValueError(f"unknown decoder byte map: {byte_map}")
+
+
+def decode_decoder_compact(raw):
+    """Decode the compact HNeRV state_dict from RAW concatenated stream bytes.
+
+    `raw` is the byte concatenation of the 7 decoder streams that
+    `codec_ctx.unpack_container` returns (per-tensor q-bytes + fp16 scale, in
+    DECODER_STORAGE_ORDER). Identical to fec6's decode_decoder_compact after
+    its Brotli step."""
+    if len(raw) != DECODER_RAW_LEN:
+        raise ValueError("bad raw decoder stream length")
+    probe = HNeRVDecoder(
+        latent_dim=LATENT_DIM,
+        base_channels=BASE_CHANNELS,
+        eval_size=EVAL_SIZE,
+    )
+    items = list(probe.state_dict().items())
+    pos = 0
+    sd = {}
+
+    for idx in DECODER_STORAGE_ORDER:
+        name, tensor = items[idx]
+        shape = tuple(tensor.shape)
+        numel = int(tensor.numel())
+        zz = np.frombuffer(raw, dtype=np.uint8, count=numel, offset=pos)
+        pos += numel
+        scale = np.frombuffer(raw, dtype=np.float16, count=1, offset=pos)[0]
+        pos += 2
+
+        q = decode_mapped_u8(zz, DECODER_BYTE_MAPS.get(idx, "zig"))
+        if len(shape) == 4:
+            storage_perm = CONV4_STORAGE_PERMS[idx]
+            inverse_perm = CONV4_INVERSE_PERMS[idx]
+            stored_shape = tuple(shape[i] for i in storage_perm)
+            q = q.reshape(stored_shape)
+            q = np.transpose(q, inverse_perm).copy()
+        else:
+            q = q.reshape(shape)
+        sd[name] = torch.from_numpy(q.astype(np.float32)) * float(scale)
+
+    if pos != len(raw):
+        raise ValueError("trailing or truncated compact decoder payload")
+    return sd
+
+
+def decode_latents_compact(raw):
+    """Decode RAW per-pair latent payload bytes into float tensors.
+
+    `raw` is what fec6's decode_latents_compact sees after its LZMA step:
+    fp16 mins + fp16 scales + centered temporal-delta uint8 codes."""
+    if len(raw) != LATENT_RAW_LEN:
+        raise ValueError("bad raw latent payload length")
+    buf = io.BytesIO(raw)
+    mins = torch.from_numpy(
+        np.frombuffer(buf.read(LATENT_DIM * 2), dtype=np.float16).copy()
+    ).float()
+    scales = torch.from_numpy(
+        np.frombuffer(buf.read(LATENT_DIM * 2), dtype=np.float16).copy()
+    ).float()
+    stored = np.frombuffer(buf.read(N_PAIRS * LATENT_DIM), dtype=np.uint8)
+    if stored.size != N_PAIRS * LATENT_DIM:
+        raise ValueError("truncated compact latent payload")
+    delta_ordered = stored.reshape(LATENT_DIM, N_PAIRS)
+    q_ordered = delta_ordered.copy()
+    q_ordered[:, 1:] = np.cumsum(
+        ((delta_ordered[:, 1:].astype(np.int16) - 128) & 255),
+        axis=1,
+        dtype=np.uint16,
+    ).astype(np.uint8) + delta_ordered[:, :1]
+    q_ordered = q_ordered.T.copy()
+    q = np.empty((N_PAIRS, LATENT_DIM), dtype=np.uint8)
+    q[:, LATENT_DIM_ORDER] = q_ordered
+    return torch.from_numpy(q.astype(np.float32)) * scales.unsqueeze(0) + mins.unsqueeze(0)

--- a/submissions/hnerv_qlp/codec_ctx.py
+++ b/submissions/hnerv_qlp/codec_ctx.py
@@ -1,0 +1,695 @@
+# SPDX-License-Identifier: MIT
+"""Context-modeled entropy coder for the #101/#110 payload sections.
+
+Replaces the off-the-shelf coders of the current #1 submission payload with
+constriction-based adaptive/parametric range coding:
+
+  decoder weights : one range stream; per-tensor adaptive 256-ary models with
+                    geometric-primed prior counts. Prior decay rho, prior
+                    strength M, floor eps, and adaptation increment are chosen
+                    per model by exact simulated code length and transmitted
+                    in a 2-byte/model header. fp16 scale low bytes are stored
+                    raw; the (highly redundant) high bytes are entropy-coded.
+  latents         : per-dim causal prediction (AR(1) on own quantized deltas,
+                    optional own-lag-2 and up to 4 already-decoded dims at the
+                    same time step; integer-quantized LS coefficients) with
+                    static discrete-Gaussian residual models (u16 parameter
+                    per dim) or, where the encoder measures a win, an
+                    adaptive Gaussian-primed model. fp16 min/scale high bytes
+                    entropy-coded like the decoder scales.
+  selector        : adaptive 16-ary model over the FEC6 mode indices
+                    (recovers the exact 249-byte FEC6 wrapper on decode).
+
+All decode-side model construction uses only IEEE-exact float64 operations
+(multiply / add / divide), so encoder and decoder build bit-identical
+probability tables on any IEEE-754 platform. Decode-side deps: numpy +
+constriction (harness base deps) (+ brotli/lzma stdlib for passthrough).
+
+Container (member produced by `pack_container`):
+  u8 version | u8 coder-id bitmap (2 bits/section: decoder, latent, selector)
+  | u24 len(decoder section) | u24 len(latent section) | selector section.
+Coder id 0 = passthrough (current bytes verbatim), 1 = this coder.
+"""
+from __future__ import annotations
+
+import math
+import struct
+
+import numpy as np
+
+try:
+    import constriction
+except ImportError:  # schema constants remain importable without it
+    constriction = None
+
+VERSION = 1
+CODER_PASSTHROUGH = 0
+CODER_CTX = 1
+
+# ---------------------------------------------------------------------------
+# fixed schema of the #101 decoder payload (verified against
+# submissions/hnerv_fec6_fixed_huffman_k16/src/codec.py and the archive)
+# ---------------------------------------------------------------------------
+# (tensor_idx, numel) per storage position; streams split per STREAM_ENDS.
+TENSOR_SCHEMA = (
+    (14, 972), (22, 1458), (7, 108), (6, 34992), (19, 18), (10, 12960),
+    (25, 3), (4, 46656), (20, 1458), (9, 80), (12, 11664), (15, 27),
+    (5, 144), (11, 72), (18, 360), (1, 1728), (21, 9), (3, 144), (27, 3),
+    (13, 72), (2, 46656), (26, 486), (24, 486), (17, 20), (16, 540),
+    (23, 18), (8, 19440), (0, 48384),
+)
+STREAM_ENDS = (1, 2, 22, 23, 26, 27, 28)
+N_STREAMS = len(STREAM_ENDS)
+N_TENSORS = len(TENSOR_SCHEMA)
+# byte maps that need a magnitude-ordering remap for the geometric prior
+TWOS_TENSORS = frozenset({20})
+OFF_TENSORS = frozenset({27})
+# tensors sharing one adaptive model (chosen by exact cost on the encoder;
+# fixed here so the decoder needs no signalling)
+SHARED_MODEL_TENSORS = frozenset({7, 5, 1, 3})
+
+M_GRID = (4.0, 16.0, 64.0, 256.0, 1024.0)          # 3 bits
+INC_GRID = (1.0, 1.5, 2.0, 3.0)                    # 2 bits
+EPS_GRID = (0.01, 0.05, 0.15, 0.4)                 # 2 bits
+
+N_PAIRS = 600
+LATENT_DIM = 28
+LATENT_HDR = 112  # fp16 mins + scales
+LATENT_ADAPT_M = 480.0
+SELECTOR_MAGIC = b"FEC6"
+FEC6_CODE_BITS = (
+    "00", "1100", "01", "111010", "11010", "111011", "111100", "100",
+    "111101", "11011", "1111110", "111110", "11111110", "101", "11100",
+    "11111111",
+)
+LAG2_SRC = 255  # spec marker: feature is own lag-2 instead of a cross dim
+
+# discrete-Gaussian parameter grid: Q_TABLE[k] = round(65535*exp(-1/(2*s^2)))
+# for s = 0.3*(80/0.3)^(k/255) -- precomputed so the decoder never calls exp().
+Q_TABLE = (
+    253, 321, 404, 502, 619, 756, 915, 1099, 1309, 1549,
+    1818, 2120, 2456, 2827, 3235, 3681, 4164, 4686, 5247, 5847,
+    6485, 7161, 7874, 8623, 9406, 10222, 11070, 11947, 12851, 13780,
+    14733, 15706, 16698, 17706, 18728, 19761, 20803, 21852, 22905, 23961,
+    25017, 26071, 27122, 28167, 29206, 30235, 31255, 32263, 33258, 34239,
+    35205, 36155, 37089, 38005, 38903, 39783, 40643, 41484, 42305, 43106,
+    43888, 44648, 45389, 46109, 46809, 47489, 48150, 48790, 49411, 50013,
+    50596, 51160, 51706, 52234, 52744, 53238, 53714, 54174, 54618, 55046,
+    55459, 55858, 56241, 56611, 56968, 57311, 57641, 57959, 58265, 58560,
+    58843, 59115, 59377, 59629, 59871, 60103, 60326, 60541, 60747, 60945,
+    61135, 61317, 61492, 61660, 61822, 61976, 62125, 62267, 62404, 62535,
+    62661, 62781, 62897, 63008, 63114, 63216, 63314, 63407, 63497, 63583,
+    63666, 63745, 63820, 63893, 63963, 64029, 64093, 64154, 64213, 64269,
+    64323, 64374, 64424, 64471, 64516, 64559, 64601, 64641, 64679, 64715,
+    64750, 64784, 64816, 64846, 64876, 64904, 64931, 64957, 64981, 65005,
+    65028, 65049, 65070, 65090, 65109, 65127, 65144, 65161, 65177, 65192,
+    65207, 65221, 65235, 65247, 65260, 65271, 65283, 65294, 65304, 65314,
+    65323, 65332, 65341, 65349, 65357, 65365, 65372, 65379, 65386, 65392,
+    65398, 65404, 65410, 65415, 65420, 65425, 65430, 65434, 65439, 65443,
+    65447, 65451, 65454, 65458, 65461, 65464, 65467, 65470, 65473, 65475,
+    65478, 65480, 65483, 65485, 65487, 65489, 65491, 65493, 65495, 65497,
+    65498, 65500, 65501, 65503, 65504, 65505, 65507, 65508, 65509, 65510,
+    65511, 65512, 65513, 65514, 65515, 65516, 65517, 65518, 65518, 65519,
+    65520, 65520, 65521, 65522, 65522, 65523, 65523, 65524, 65524, 65525,
+    65525, 65526, 65526, 65526, 65527, 65527, 65527, 65528, 65528, 65528,
+    65529, 65529, 65529, 65529, 65530, 65530,
+)
+
+
+# ---------------------------------------------------------------------------
+# deterministic model construction helpers
+# ---------------------------------------------------------------------------
+def _geometric_pmf(rho_q: int) -> np.ndarray:
+    """pmf[k] = (1-r) * r^k built by repeated IEEE multiplication."""
+    r = rho_q / 255.0
+    out = np.empty(256, np.float64)
+    v = 1.0 - r
+    for k in range(256):
+        out[k] = v
+        v = v * r
+    return out
+
+
+def _remap_table(tensor_idx: int) -> np.ndarray:
+    """Map stored byte -> magnitude-ordered index used by the prior."""
+    v = np.arange(256, dtype=np.int64)
+    if tensor_idx in TWOS_TENSORS:
+        x = np.where(v >= 128, v - 256, v)
+    elif tensor_idx in OFF_TENSORS:
+        x = v - 128
+    else:
+        return v
+    return np.where(x >= 0, 2 * x, -2 * x - 1)
+
+
+def _prior_counts(rho_q: int, m_idx: int, eps_idx: int,
+                  remap: np.ndarray) -> np.ndarray:
+    geo = _geometric_pmf(rho_q)
+    return EPS_GRID[eps_idx] + M_GRID[m_idx] * geo[remap]
+
+
+def _gauss_pmf_from_q(q_u16: int) -> np.ndarray:
+    """Discrete Gaussian pmf[k] proportional to q^(k^2), k in [-128, 127].
+
+    Built with exact float64 multiplications only (binary exponentiation), so
+    it is bit-identical across IEEE platforms. Unnormalized (constriction
+    normalizes internally); underflow to 0.0 is fine (constriction floors)."""
+    q = q_u16 / 65535.0
+    out = np.empty(256, np.float64)
+    for i in range(256):
+        k = i - 128
+        e = k * k
+        acc = 1.0
+        base = q
+        while e:
+            if e & 1:
+                acc *= base
+            base *= base
+            e >>= 1
+        out[i] = acc
+    return out
+
+
+def _pmf_bits(pmf: np.ndarray, symbols: np.ndarray) -> float:
+    p = pmf / pmf.sum()
+    p = np.maximum(p, 1e-300)
+    return float(-np.log2(p[symbols]).sum())
+
+
+def _cumcount(a: np.ndarray) -> np.ndarray:
+    """out[t] = number of previous occurrences of a[t] in a[:t]."""
+    order = np.argsort(a, kind="stable")
+    sa = a[order]
+    starts = np.flatnonzero(np.concatenate([[True], sa[1:] != sa[:-1]]))
+    sizes = np.diff(np.concatenate([starts, [len(sa)]]))
+    grp = np.repeat(np.arange(len(starts)), sizes)
+    cc = np.arange(len(sa)) - starts[grp]
+    out = np.empty(len(a), np.int64)
+    out[order] = cc
+    return out
+
+
+def _sim_adaptive_bits(symbols: np.ndarray, cc: np.ndarray,
+                       prior: np.ndarray, inc: float) -> float:
+    """Exact code length of adaptive AC: P_t(s) = (a_s + inc*c) / (A + inc*t)."""
+    A = float(prior.sum())
+    n = len(symbols)
+    num = prior[symbols] + inc * cc
+    den = A + inc * np.arange(n, dtype=np.float64)
+    return float(np.log2(den).sum() - np.log2(num).sum())
+
+
+def _adaptive_dm_bits(symbols: np.ndarray, prior: np.ndarray) -> float:
+    return _sim_adaptive_bits(symbols, _cumcount(symbols), prior, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# fp16 high-byte coding (scales / mins are tightly clustered in exponent)
+# ---------------------------------------------------------------------------
+def _encode_hi_bytes(enc, hi: np.ndarray) -> bytes:
+    """Encode high bytes into `enc`; returns 2-byte (base, width) header."""
+    base = int(hi.min())
+    width = int(hi.max()) - base + 1
+    counts = np.full(width, 0.5, np.float64)
+    Cat = constriction.stream.model.Categorical
+    for v in (hi.astype(np.int64) - base).tolist():
+        enc.encode(v, Cat(counts, lazy=True))
+        counts[v] += 1.0
+    return struct.pack("<BB", base, width)
+
+
+def _decode_hi_bytes(dec, base: int, width: int, n: int) -> np.ndarray:
+    counts = np.full(width, 0.5, np.float64)
+    Cat = constriction.stream.model.Categorical
+    out = np.empty(n, np.uint8)
+    for i in range(n):
+        v = dec.decode(Cat(counts, lazy=True))
+        out[i] = base + v
+        counts[v] += 1.0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# section 1: decoder weight streams
+# ---------------------------------------------------------------------------
+def _decoder_model_plan():
+    """Per-storage-pos model key + model keys in first-use order."""
+    model_of, keys = [], {}
+    for tidx, _ in TENSOR_SCHEMA:
+        key = "shared" if tidx in SHARED_MODEL_TENSORS else f"t{tidx}"
+        model_of.append(key)
+        if key not in keys:
+            keys[key] = len(keys)
+    return model_of, keys
+
+
+def _split_streams_to_tensors(raws: list[bytes]):
+    """raws (7 streams) -> (per-pos weight byte arrays, per-pos 2B scales)."""
+    weights, scales = [], []
+    start = 0
+    for si, end in enumerate(STREAM_ENDS):
+        data = np.frombuffer(raws[si], np.uint8)
+        pos = 0
+        for p in range(start, end):
+            _tidx, numel = TENSOR_SCHEMA[p]
+            weights.append(data[pos:pos + numel].copy())
+            scales.append(bytes(data[pos + numel:pos + numel + 2]))
+            pos += numel + 2
+        if pos != len(data):
+            raise ValueError(f"stream {si} length mismatch")
+        start = end
+    return weights, scales
+
+
+def _tensors_to_streams(weights, scales) -> list[bytes]:
+    out, start = [], 0
+    for end in STREAM_ENDS:
+        parts = []
+        for p in range(start, end):
+            parts.append(weights[p].astype(np.uint8).tobytes())
+            parts.append(scales[p])
+        out.append(b"".join(parts))
+        start = end
+    return out
+
+
+def _search_model_params(m: np.ndarray) -> tuple[int, int, int, int]:
+    """Pick (rho_q, m_idx, inc_idx, eps_idx) minimizing simulated bits."""
+    cc = _cumcount(m)
+    mu = max(float(m.mean()), 0.05)
+    rho0 = int(np.clip(round(255.0 * mu / (1.0 + mu)), 1, 254))
+    best = None
+    geos = {}
+    for stage, offsets in ((0, range(-12, 13, 4)), (1, range(-3, 4, 1))):
+        center = rho0 if stage == 0 else best[1]
+        for dr in offsets:
+            rho_q = int(np.clip(center + dr, 1, 254))
+            if rho_q not in geos:
+                geos[rho_q] = _geometric_pmf(rho_q)
+            geo = geos[rho_q]
+            for m_idx, M in enumerate(M_GRID):
+                for eps_idx, eps in enumerate(EPS_GRID):
+                    prior = eps + M * geo
+                    for inc_idx, inc in enumerate(INC_GRID):
+                        bits = _sim_adaptive_bits(m, cc, prior, inc)
+                        cand = (bits, rho_q, m_idx, inc_idx, eps_idx)
+                        if best is None or cand[0] < best[0]:
+                            best = cand
+    return best[1], best[2], best[3], best[4]
+
+
+def encode_decoder_section(raws: list[bytes]) -> bytes:
+    weights, scales = _split_streams_to_tensors(raws)
+    model_of, keys = _decoder_model_plan()
+
+    model_syms = {k: [] for k in keys}
+    for pos, w in enumerate(weights):
+        tidx, _ = TENSOR_SCHEMA[pos]
+        model_syms[model_of[pos]].append(_remap_table(tidx)[w])
+    params = {k: _search_model_params(np.concatenate(model_syms[k]))
+              for k in keys}
+
+    scale_bytes = b"".join(scales)
+    lo = np.frombuffer(scale_bytes, np.uint8)[0::2]
+    hi = np.frombuffer(scale_bytes, np.uint8)[1::2]
+
+    enc = constriction.stream.queue.RangeEncoder()
+    hi_hdr = _encode_hi_bytes(enc, hi)
+
+    Cat = constriction.stream.model.Categorical
+    model_counts, model_inc = {}, {}
+    for pos, w in enumerate(weights):
+        tidx, _ = TENSOR_SCHEMA[pos]
+        key = model_of[pos]
+        if key not in model_counts:
+            rho_q, m_idx, inc_idx, eps_idx = params[key]
+            model_counts[key] = _prior_counts(rho_q, m_idx, eps_idx,
+                                              _remap_table(tidx))
+            model_inc[key] = INC_GRID[inc_idx]
+        counts, inc = model_counts[key], model_inc[key]
+        for v in w.tolist():
+            enc.encode(v, Cat(counts, lazy=True))
+            counts[v] += inc
+    body = enc.get_compressed().astype("<u4").tobytes()
+
+    hdr = [lo.tobytes(), hi_hdr]
+    hdr.append(bytes(params[k][0] for k in keys))                     # rho
+    hdr.append(bytes((params[k][1] | (params[k][2] << 3)
+                      | (params[k][3] << 5)) for k in keys))          # M|inc|eps
+    return b"".join(hdr) + body
+
+
+def decode_decoder_section(blob: bytes) -> list[bytes]:
+    model_of, keys = _decoder_model_plan()
+    n_models = len(keys)
+    p = 0
+    lo = np.frombuffer(blob[p:p + N_TENSORS], np.uint8)
+    p += N_TENSORS
+    hi_base, hi_width = struct.unpack_from("<BB", blob, p)
+    p += 2
+    rho_bytes = blob[p:p + n_models]
+    p += n_models
+    packed = blob[p:p + n_models]
+    p += n_models
+    params = {}
+    for i, k in enumerate(keys):
+        b = packed[i]
+        params[k] = (rho_bytes[i], b & 7, (b >> 3) & 3, (b >> 5) & 3)
+
+    words = np.frombuffer(blob[p:], dtype="<u4").astype(np.uint32)
+    dec = constriction.stream.queue.RangeDecoder(words)
+    hi = _decode_hi_bytes(dec, hi_base, hi_width, N_TENSORS)
+    scale_arr = np.empty(2 * N_TENSORS, np.uint8)
+    scale_arr[0::2] = lo
+    scale_arr[1::2] = hi
+    scales = [scale_arr[2 * i:2 * i + 2].tobytes() for i in range(N_TENSORS)]
+
+    Cat = constriction.stream.model.Categorical
+    model_counts, model_inc = {}, {}
+    weights = []
+    for pos, (tidx, numel) in enumerate(TENSOR_SCHEMA):
+        key = model_of[pos]
+        if key not in model_counts:
+            rho_q, m_idx, inc_idx, eps_idx = params[key]
+            model_counts[key] = _prior_counts(rho_q, m_idx, eps_idx,
+                                              _remap_table(tidx))
+            model_inc[key] = INC_GRID[inc_idx]
+        counts, inc = model_counts[key], model_inc[key]
+        out = np.empty(numel, np.uint8)
+        for i in range(numel):
+            v = dec.decode(Cat(counts, lazy=True))
+            out[i] = v
+            counts[v] += inc
+        weights.append(out)
+    return _tensors_to_streams(weights, scales)
+
+
+# ---------------------------------------------------------------------------
+# section 2: latents
+# ---------------------------------------------------------------------------
+def _latent_signed_deltas(codes: np.ndarray) -> np.ndarray:
+    d = (codes[:, 1:].astype(np.int64) - 128) & 255
+    return np.where(d >= 128, d - 256, d)
+
+
+def _fit_q_idx(res: np.ndarray) -> tuple[int, float]:
+    """Q_TABLE index minimizing exact coded bits for the residuals."""
+    sig = max(float(res.std()), 0.35)
+    k0 = int(np.clip(round(255.0 * math.log(sig / 0.3)
+                           / math.log(80.0 / 0.3)), 0, 255))
+    syms = (res + 128).astype(np.int64)
+    best = None
+    for dk in range(-14, 15, 2):
+        k = int(np.clip(k0 + dk, 0, 255))
+        bits = _pmf_bits(_gauss_pmf_from_q(Q_TABLE[k]), syms)
+        if best is None or bits < best[1]:
+            best = (k, bits)
+    k_center = best[0]
+    for dk in (-1, 1):
+        k = int(np.clip(k_center + dk, 0, 255))
+        bits = _pmf_bits(_gauss_pmf_from_q(Q_TABLE[k]), syms)
+        if bits < best[1]:
+            best = (k, bits)
+    return best
+
+
+def encode_latent_section(latent_raw: bytes) -> bytes:
+    lat = np.frombuffer(latent_raw, np.uint8)
+    if len(lat) != LATENT_HDR + LATENT_DIM * N_PAIRS:
+        raise ValueError("unexpected latent payload length")
+    hdr16 = lat[:LATENT_HDR]
+    lo = hdr16[0::2]
+    hi = hdr16[1::2]
+    codes = lat[LATENT_HDR:].reshape(LATENT_DIM, N_PAIRS)
+    first_col = bytes(codes[:, 0])
+    sd = _latent_signed_deltas(codes)  # (28, 599)
+    T = N_PAIRS - 1
+
+    C = np.corrcoef(sd.astype(np.float64))
+    own_f = sd.astype(np.float64)
+    specs, all_syms = [], []
+    for i in range(LATENT_DIM):
+        ar1 = np.concatenate([[0.0], own_f[i, :-1]])
+        lag2 = np.concatenate([[0.0, 0.0], own_f[i, :-2]])
+        lag2_corr = abs(np.corrcoef(sd[i, 2:], sd[i, :-2])[0, 1])
+        cands = sorted(range(i), key=lambda k: -abs(C[i, k]))
+        cands = [(k, abs(C[i, k])) for k in cands if abs(C[i, k]) > 0.10][:4]
+        cands.append((LAG2_SRC, lag2_corr))
+        cands.sort(key=lambda kc: -kc[1])
+        best = None
+        for ncand in range(len(cands) + 1):
+            feats = [ar1]
+            for k, _ in cands[:ncand]:
+                feats.append(lag2 if k == LAG2_SRC else own_f[k])
+            X = np.stack(feats, 1)
+            coef, *_ = np.linalg.lstsq(X, own_f[i], rcond=None)
+            cq = np.clip(np.round(coef * 64.0), -127, 127).astype(np.int64)
+            num = (X.astype(np.int64) * cq).sum(axis=1)
+            pred = (num + 32) >> 6
+            r = ((sd[i] - pred + 128) & 255) - 128
+            q_idx, bits = _fit_q_idx(r)
+            cost = bits + 8.0 * (2 * ncand)
+            if best is None or cost < best[0]:
+                best = (cost, cq, cands[:ncand], q_idx, r)
+        _, cq, used, q_idx, r = best
+        syms = (r + 128).astype(np.int64)
+        # static vs Gaussian-primed adaptive residual model
+        pmf = _gauss_pmf_from_q(Q_TABLE[q_idx])
+        static_bits = _pmf_bits(pmf, syms)
+        prior = 1e-4 + LATENT_ADAPT_M * (pmf / pmf.sum())
+        adapt_bits = _adaptive_dm_bits(syms, prior)
+        adaptive = bool(adapt_bits + 2.0 < static_bits)
+        specs.append((int(cq[0]),
+                      [(k, int(c)) for (k, _), c in zip(used, cq[1:])],
+                      q_idx, adaptive))
+        all_syms.append(syms)
+
+    out = [lo.tobytes(), first_col]
+    for ar1_q, cross, q_idx, adaptive in specs:
+        out.append(struct.pack("<Bb", q_idx, ar1_q))
+    nib = bytearray(LATENT_DIM // 2)
+    for i, (_, cross, _, adaptive) in enumerate(specs):
+        v = len(cross) | (8 if adaptive else 0)
+        nib[i // 2] |= v << (4 * (i % 2))
+    out.append(bytes(nib))
+    for _, cross, _, _ in specs:
+        for k, c in cross:
+            out.append(struct.pack("<Bb", k, c))
+
+    enc = constriction.stream.queue.RangeEncoder()
+    # mins-hi and scales-hi are two distinct exponent clusters: separate models
+    hi_hdr = _encode_hi_bytes(enc, hi[:LATENT_DIM]) \
+        + _encode_hi_bytes(enc, hi[LATENT_DIM:])
+    out.insert(1, hi_hdr)
+    Cat = constriction.stream.model.Categorical
+    for i in range(LATENT_DIM):
+        q_idx, adaptive = specs[i][2], specs[i][3]
+        pmf = _gauss_pmf_from_q(Q_TABLE[q_idx])
+        if adaptive:
+            counts = 1e-4 + LATENT_ADAPT_M * (pmf / pmf.sum())
+            for v in all_syms[i].tolist():
+                enc.encode(v, Cat(counts, lazy=True))
+                counts[v] += 1.0
+        else:
+            enc.encode(all_syms[i].astype(np.int32), Cat(pmf, perfect=False))
+    out.append(enc.get_compressed().astype("<u4").tobytes())
+    return b"".join(out)
+
+
+def decode_latent_section(blob: bytes) -> bytes:
+    p = 0
+    lo = np.frombuffer(blob[p:p + LATENT_HDR // 2], np.uint8)
+    p += LATENT_HDR // 2
+    hb0, hw0, hb1, hw1 = struct.unpack_from("<BBBB", blob, p)
+    p += 4
+    first_col = np.frombuffer(blob[p:p + LATENT_DIM], np.uint8)
+    p += LATENT_DIM
+    qa = []
+    for _ in range(LATENT_DIM):
+        q_idx, ar1 = struct.unpack_from("<Bb", blob, p)
+        p += 2
+        qa.append((q_idx, ar1))
+    nib = blob[p:p + LATENT_DIM // 2]
+    p += LATENT_DIM // 2
+    specs = []
+    for i in range(LATENT_DIM):
+        v = (nib[i // 2] >> (4 * (i % 2))) & 0xF
+        specs.append([qa[i][1], v & 7, qa[i][0], bool(v & 8)])
+    for i in range(LATENT_DIM):
+        cross = []
+        for _ in range(specs[i][1]):
+            k, c = struct.unpack_from("<Bb", blob, p)
+            p += 2
+            cross.append((k, c))
+        specs[i][1] = cross
+
+    words = np.frombuffer(blob[p:], dtype="<u4").astype(np.uint32)
+    dec = constriction.stream.queue.RangeDecoder(words)
+    hi = np.concatenate([_decode_hi_bytes(dec, hb0, hw0, LATENT_DIM),
+                         _decode_hi_bytes(dec, hb1, hw1, LATENT_DIM)])
+    hdr16 = np.empty(LATENT_HDR, np.uint8)
+    hdr16[0::2] = lo
+    hdr16[1::2] = hi
+
+    Cat = constriction.stream.model.Categorical
+    T = N_PAIRS - 1
+    sd = np.zeros((LATENT_DIM, T), np.int64)
+    for i in range(LATENT_DIM):
+        ar1, cross, q_idx, adaptive = specs[i]
+        pmf = _gauss_pmf_from_q(Q_TABLE[q_idx])
+        if adaptive:
+            counts = 1e-4 + LATENT_ADAPT_M * (pmf / pmf.sum())
+            syms = np.empty(T, np.int64)
+            for t in range(T):
+                v = dec.decode(Cat(counts, lazy=True))
+                syms[t] = v
+                counts[v] += 1.0
+        else:
+            syms = np.asarray(dec.decode(Cat(pmf, perfect=False), T),
+                              dtype=np.int64)
+        r = syms - 128
+        cross_term = np.zeros(T, np.int64)
+        lag2_coef = 0
+        for k, c in cross:
+            if k == LAG2_SRC:
+                lag2_coef = c
+            else:
+                cross_term += c * sd[k]
+        row = sd[i]
+        prev = prev2 = 0
+        for t in range(T):
+            num = ar1 * prev + lag2_coef * prev2 + int(cross_term[t])
+            pred = (num + 32) >> 6
+            v = ((r[t] + pred + 128) & 255) - 128
+            row[t] = v
+            prev2 = prev
+            prev = v
+    codes = np.empty((LATENT_DIM, N_PAIRS), np.uint8)
+    codes[:, 0] = first_col
+    codes[:, 1:] = ((sd + 128) & 255).astype(np.uint8)
+    return hdr16.tobytes() + codes.tobytes()
+
+
+# ---------------------------------------------------------------------------
+# section 3: FEC6 selector
+# ---------------------------------------------------------------------------
+def _selector_codes_from_payload(payload: bytes) -> np.ndarray:
+    if payload[:4] != SELECTOR_MAGIC:
+        raise ValueError("not a FEC6 selector payload")
+    n_pairs = struct.unpack_from("<H", payload, 4)[0]
+    decode = {b: i for i, b in enumerate(FEC6_CODE_BITS)}
+    bits = np.unpackbits(np.frombuffer(payload[6:], np.uint8))
+    codes, prefix = [], ""
+    for bit in bits:
+        prefix += "1" if bit else "0"
+        if prefix in decode:
+            codes.append(decode[prefix])
+            prefix = ""
+            if len(codes) == n_pairs:
+                break
+    if len(codes) != n_pairs:
+        raise ValueError("truncated FEC6 bitstream")
+    return np.array(codes, np.int64)
+
+
+def _selector_payload_from_codes(codes: np.ndarray) -> bytes:
+    bitstr = "".join(FEC6_CODE_BITS[c] for c in codes.tolist())
+    bitstr += "0" * ((-len(bitstr)) % 8)
+    body = int(bitstr, 2).to_bytes(len(bitstr) // 8, "big") if bitstr else b""
+    return SELECTOR_MAGIC + struct.pack("<H", len(codes)) + body
+
+
+def encode_selector_section(payload: bytes) -> bytes:
+    codes = _selector_codes_from_payload(payload)
+    enc = constriction.stream.queue.RangeEncoder()
+    Cat = constriction.stream.model.Categorical
+    counts = np.full(16, 0.6, np.float64)
+    for c in codes.tolist():
+        enc.encode(c, Cat(counts, lazy=True))
+        counts[c] += 1.0
+    return enc.get_compressed().astype("<u4").tobytes()
+
+
+def decode_selector_section(blob: bytes) -> bytes:
+    words = np.frombuffer(blob, dtype="<u4").astype(np.uint32)
+    dec = constriction.stream.queue.RangeDecoder(words)
+    Cat = constriction.stream.model.Categorical
+    counts = np.full(16, 0.6, np.float64)
+    codes = np.empty(N_PAIRS, np.int64)
+    for i in range(N_PAIRS):
+        c = dec.decode(Cat(counts, lazy=True))
+        codes[i] = c
+        counts[c] += 1.0
+    return _selector_payload_from_codes(codes)
+
+
+# ---------------------------------------------------------------------------
+# container
+# ---------------------------------------------------------------------------
+def pack_container(decoder_sec: bytes, latent_sec: bytes, selector_sec: bytes,
+                   coder_ids: tuple[int, int, int]) -> bytes:
+    head = bytes([(VERSION << 4) | coder_ids[0] | (coder_ids[1] << 1)
+                  | (coder_ids[2] << 2)])
+    head += len(decoder_sec).to_bytes(3, "little")
+    head += len(latent_sec).to_bytes(3, "little")
+    return head + decoder_sec + latent_sec + selector_sec
+
+
+def unpack_container(blob: bytes):
+    """-> (decoder_streams: list[bytes], latent_raw: bytes, selector: bytes)."""
+    if blob[0] >> 4 != VERSION:
+        raise ValueError("bad container version")
+    ids = (blob[0] & 1, (blob[0] >> 1) & 1, (blob[0] >> 2) & 1)
+    ld = int.from_bytes(blob[1:4], "little")
+    ll = int.from_bytes(blob[4:7], "little")
+    p = 7
+    dec_sec = blob[p:p + ld]
+    p += ld
+    lat_sec = blob[p:p + ll]
+    p += ll
+    sel_sec = blob[p:]
+
+    if ids[0] == CODER_CTX:
+        streams = decode_decoder_section(dec_sec)
+    else:
+        streams = _split_legacy_brotli(dec_sec)
+    if ids[1] == CODER_CTX:
+        latent_raw = decode_latent_section(lat_sec)
+    else:
+        import lzma
+        latent_raw = lzma.decompress(
+            lat_sec, format=lzma.FORMAT_RAW,
+            filters=[{"id": lzma.FILTER_LZMA1, "dict_size": 4096,
+                      "lc": 3, "lp": 0, "pb": 0}])
+    selector = decode_selector_section(sel_sec) if ids[2] == CODER_CTX else sel_sec
+    return streams, latent_raw, selector
+
+
+def _split_legacy_brotli(data: bytes) -> list[bytes]:
+    import brotli
+    out, pos = [], 0
+    for _ in range(N_STREAMS):
+        dec = brotli.Decompressor()
+        chunks = []
+        while pos < len(data) and not dec.is_finished():
+            chunks.append(dec.process(data[pos:pos + 1]))
+            pos += 1
+        if not dec.is_finished():
+            raise ValueError("truncated legacy decoder payload")
+        out.append(b"".join(chunks))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# reporting
+# ---------------------------------------------------------------------------
+def summary_table(rows: list[tuple[str, int, int]]) -> str:
+    """rows: (section, current_bytes, new_bytes) -> formatted table."""
+    lines = [f"{'section':<12} {'current':>10} {'ctx-coder':>10} {'delta':>8}"]
+    tc = tn = 0
+    for name, cur, new in rows:
+        tc += cur
+        tn += new
+        lines.append(f"{name:<12} {cur:>10,} {new:>10,} {new - cur:>+8,}")
+    lines.append(f"{'TOTAL':<12} {tc:>10,} {tn:>10,} {tn - tc:>+8,}")
+    return "\n".join(lines)

--- a/submissions/hnerv_qlp/encoder/extract_payload.py
+++ b/submissions/hnerv_qlp/encoder/extract_payload.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Extract the leaderboard-#1 payload into training-ready tensors.
+
+Reads the PR #110 (fec6) archive — whose information content equals the
+current #1 (PR #112 rhnerv_comma, a lossless re-code) — and writes to work/:
+
+  payload.pt:
+    decoder_sd     : dict[str, float32 tensor]  (PR #95 weights, frozen forever)
+    latents_grid   : (600, 28) float32 — uint8-grid latents, NO sidecar
+    latents_eff    : (600, 28) float32 — sidecar-applied (the shipping values)
+    q_codes        : (600, 28) uint8   — raw grid codes
+    mins, scales   : (28,) float32     — per-dim dequant grid (fp16-exact)
+    selector_codes : (600,) int64      — FEC6 K=16 per-pair mode indices
+    selector_specs : list of (family, params, frame_index)
+    meta           : dict
+
+The quantization grid (mins/scales) is kept FIXED during polish so the
+re-encoded latent payload stays format-identical to PR #101's grammar.
+"""
+from __future__ import annotations
+
+import lzma
+import sys
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import torch
+
+HERE = Path(__file__).resolve().parent
+QLP_DIR = HERE.parent
+REPO = QLP_DIR.parent.parent
+FEC6 = REPO / "submissions" / "hnerv_fec6_fixed_huffman_k16"
+sys.path.insert(0, str(FEC6 / "src"))
+sys.path.insert(0, str(FEC6))
+
+from inflate import parse_pr101_frame_selector_archive  # noqa: E402
+from codec import (  # noqa: E402
+    parse_archive,
+    decode_latents_compact,
+    DECODER_BLOB_LEN,
+    LATENT_BLOB_LEN,
+    LATENT_LZMA_FILTERS,
+    LATENT_DIM,
+    N_PAIRS,
+)
+
+
+def main() -> None:
+    work = QLP_DIR / "work"
+    archive_zip = work / "pr110_archive.zip"
+    with zipfile.ZipFile(archive_zip) as zf:
+        bin_bytes = zf.read("x")
+
+    source_payload, sel_kind, sel_codes, sel_specs = (
+        parse_pr101_frame_selector_archive(bin_bytes))
+    assert sel_kind == "compact" and len(sel_codes) == N_PAIRS
+
+    decoder_sd, latents_eff, meta = parse_archive(source_payload)
+
+    latent_blob = source_payload[DECODER_BLOB_LEN:DECODER_BLOB_LEN + LATENT_BLOB_LEN]
+    latents_grid = decode_latents_compact(latent_blob)
+
+    raw = lzma.decompress(latent_blob, format=lzma.FORMAT_RAW,
+                          filters=LATENT_LZMA_FILTERS)
+    mins = np.frombuffer(raw[: LATENT_DIM * 2], dtype=np.float16).astype(np.float32)
+    scales = np.frombuffer(raw[LATENT_DIM * 2: LATENT_DIM * 4],
+                           dtype=np.float16).astype(np.float32)
+
+    # Recover the raw grid codes by inverting the dequant (exact: grid values
+    # are min + q*scale in float32).
+    q = torch.round((latents_grid - torch.from_numpy(mins)) /
+                    torch.from_numpy(scales)).to(torch.uint8)
+    recon = torch.from_numpy(mins) + q.float() * torch.from_numpy(scales)
+    assert torch.equal(recon, latents_grid), "grid code inversion mismatch"
+
+    sidecar_delta = latents_eff - latents_grid
+    n_side = int((sidecar_delta.abs() > 1e-9).any(dim=1).sum())
+
+    torch.save({
+        "decoder_sd": decoder_sd,
+        "latents_grid": latents_grid,
+        "latents_eff": latents_eff,
+        "q_codes": q,
+        "mins": torch.from_numpy(mins.copy()),
+        "scales": torch.from_numpy(scales.copy()),
+        "selector_codes": torch.tensor(sel_codes, dtype=torch.int64),
+        "selector_specs": list(sel_specs),
+        "meta": meta,
+    }, work / "payload.pt")
+
+    n_params = sum(v.numel() for v in decoder_sd.values())
+    print(f"decoder tensors: {len(decoder_sd)} ({n_params:,} params)")
+    print(f"latents: {tuple(latents_eff.shape)}  grid step mean: {scales.mean():.5f}")
+    print(f"sidecar-corrected pairs: {n_side}/{N_PAIRS} "
+          f"(|delta| max {sidecar_delta.abs().max():.4f})")
+    print(f"selector: {len(sel_codes)} codes over K={len(sel_specs)} modes, "
+          f"non-identity: {int(sum(1 for c in sel_codes if sel_specs[c][0] != 'identity'))}")
+    print(f"wrote {work / 'payload.pt'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/hnerv_qlp/encoder/latent_codec.py
+++ b/submissions/hnerv_qlp/encoder/latent_codec.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Encode latent grid codes into PR #101's raw latent payload grammar.
+
+Inverse of hnerv_fec6_fixed_huffman_k16/src/codec.py::decode_latents_compact
+(pre-LZMA layer). The 16,912-byte raw payload is what rhnerv_comma's ctx
+coder (codec_ctx.encode_latent_section) consumes:
+
+  mins   fp16[28] | scales fp16[28] | delta stream uint8[28*600]
+
+where the delta stream is dim-major in LATENT_DIM_ORDER, first column raw,
+subsequent columns (q[j] - q[j-1] + 128) mod 256.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent.parent
+FEC6_SRC = REPO / "submissions" / "hnerv_fec6_fixed_huffman_k16" / "src"
+
+# fec6's codec.py needs its sibling modules resolvable; several submissions
+# ship modules named `codec`/`model`, so load codec.py itself by explicit path.
+sys.path.insert(0, str(FEC6_SRC))
+import importlib.util as _ilu  # noqa: E402
+
+_spec = _ilu.spec_from_file_location("_fec6_codec", FEC6_SRC / "codec.py")
+_fec6_codec = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_fec6_codec)
+LATENT_DIM = _fec6_codec.LATENT_DIM
+LATENT_DIM_ORDER = _fec6_codec.LATENT_DIM_ORDER
+N_PAIRS = _fec6_codec.N_PAIRS
+
+
+def encode_raw_latent_payload(q_codes: torch.Tensor,
+                              mins: torch.Tensor,
+                              scales: torch.Tensor) -> bytes:
+    """(600, 28) uint8 codes + fp32 grid -> 16,912-byte raw payload."""
+    q = q_codes.cpu().numpy().astype(np.uint8)
+    assert q.shape == (N_PAIRS, LATENT_DIM)
+    q_ordered = q[:, list(LATENT_DIM_ORDER)].T.astype(np.int16)  # (28, 600)
+
+    delta = np.empty_like(q_ordered, dtype=np.uint8)
+    delta[:, 0] = q_ordered[:, 0].astype(np.uint8)
+    diffs = (q_ordered[:, 1:] - q_ordered[:, :-1]) & 255
+    delta[:, 1:] = ((diffs + 128) & 255).astype(np.uint8)
+
+    out = bytearray()
+    out += mins.cpu().numpy().astype(np.float16).tobytes()
+    out += scales.cpu().numpy().astype(np.float16).tobytes()
+    out += delta.tobytes()
+    return bytes(out)
+
+
+def quantize_to_grid(latents: torch.Tensor, mins: torch.Tensor,
+                     scales: torch.Tensor) -> torch.Tensor:
+    """Continuous latents -> uint8 grid codes (clamped)."""
+    codes = torch.round((latents - mins) / scales).clamp(0, 255)
+    return codes.to(torch.uint8)
+
+
+def dequantize(q_codes: torch.Tensor, mins: torch.Tensor,
+               scales: torch.Tensor) -> torch.Tensor:
+    return mins + q_codes.float() * scales
+
+
+def _selftest() -> None:
+    """Byte-exact round trip against the original PR #101 latent blob."""
+    import lzma
+    import zipfile
+
+    sys.path.insert(0, str(FEC6_SRC.parent))
+    from inflate import parse_pr101_frame_selector_archive
+    DECODER_BLOB_LEN = _fec6_codec.DECODER_BLOB_LEN
+    LATENT_BLOB_LEN = _fec6_codec.LATENT_BLOB_LEN
+    LATENT_LZMA_FILTERS = _fec6_codec.LATENT_LZMA_FILTERS
+
+    work = HERE.parent / "work"
+    payload = torch.load(work / "payload.pt", weights_only=False)
+
+    with zipfile.ZipFile(work / "pr110_archive.zip") as zf:
+        bin_bytes = zf.read("x")
+    source_payload, _, _, _ = parse_pr101_frame_selector_archive(bin_bytes)
+    latent_blob = source_payload[DECODER_BLOB_LEN:DECODER_BLOB_LEN + LATENT_BLOB_LEN]
+    raw_orig = lzma.decompress(latent_blob, format=lzma.FORMAT_RAW,
+                               filters=LATENT_LZMA_FILTERS)
+
+    raw_ours = encode_raw_latent_payload(
+        payload["q_codes"], payload["mins"], payload["scales"])
+    assert raw_ours == raw_orig, (
+        f"raw payload mismatch: {len(raw_ours)} vs {len(raw_orig)} bytes")
+    print(f"round-trip OK: {len(raw_ours):,} bytes byte-exact vs PR #101")
+
+    deq = dequantize(payload["q_codes"], payload["mins"], payload["scales"])
+    assert torch.equal(deq, payload["latents_grid"])
+    print("dequantize OK: matches latents_grid exactly")
+
+
+if __name__ == "__main__":
+    _selftest()

--- a/submissions/hnerv_qlp/encoder/pack.py
+++ b/submissions/hnerv_qlp/encoder/pack.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Pack polished latents into a rhnerv_comma-style ctx container archive.
+
+Member layout (no trailing sidecar — the polish subsumes it):
+  [7B header | decoder section | latent section | selector section]
+
+Decoder and selector sections are byte-identical to PR #112's (the decoder
+raw streams come verbatim from PR #101, the FEC6 selector wire payload from
+PR #110). Only the latent section is rebuilt from the polished grid codes,
+per-section best-of {ctx range coder, PR #101 raw-LZMA1}.
+
+Usage:
+  python pack.py --codes work/pilot_run/best_codes.pt --out work/archive.zip
+"""
+from __future__ import annotations
+
+import argparse
+import lzma
+import sys
+import zipfile
+from pathlib import Path
+
+import torch
+
+HERE = Path(__file__).resolve().parent
+QLP_DIR = HERE.parent
+REPO = QLP_DIR.parent.parent
+RHNERV = REPO / "submissions" / "rhnerv_comma"
+sys.path.insert(0, str(RHNERV))
+sys.path.insert(0, str(HERE))
+
+import codec_ctx as cc  # noqa: E402
+from latent_codec import encode_raw_latent_payload  # noqa: E402
+
+DECODER_BLOB_LEN = 162_164
+LATENT_BLOB_LEN = 15_387
+SELECTOR_LEN = 249
+LZMA_FILTERS = [{"id": lzma.FILTER_LZMA1, "dict_size": 4096,
+                 "lc": 3, "lp": 0, "pb": 0}]
+
+
+def write_stored_zip(zip_path: Path, member_name: str, payload: bytes) -> None:
+    info = zipfile.ZipInfo(member_name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.compress_type = zipfile.ZIP_STORED
+    info.external_attr = 0o644 << 16
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr(info, payload)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--codes", type=Path, required=True,
+                    help="best_codes.pt from polish.py")
+    ap.add_argument("--out", type=Path, default=QLP_DIR / "work" / "archive.zip")
+    args = ap.parse_args()
+
+    work = QLP_DIR / "work"
+
+    # Decoder raw streams + selector wire payload, verbatim from upstream.
+    payload101 = zipfile.ZipFile(work / "pr101_archive.zip").read("x")
+    decoder_blob = payload101[:DECODER_BLOB_LEN]
+    raws = cc._split_legacy_brotli(decoder_blob)
+    payload110 = zipfile.ZipFile(work / "pr110_archive.zip").read("x")
+    selector = payload110[-SELECTOR_LEN:]
+    assert selector[:4] == b"FEC6"
+
+    # Polished latent section.
+    ck = torch.load(args.codes, weights_only=False)
+    latent_raw = encode_raw_latent_payload(ck["q_codes"], ck["mins"], ck["scales"])
+    print(f"polished latent raw payload: {len(latent_raw):,} B "
+          f"(seg={ck['seg'].mean():.8f} pose={ck['pose'].mean():.8f} on GPU axis)")
+
+    sections = [
+        ("decoder", decoder_blob, cc.encode_decoder_section(raws)),
+        ("latents", lzma.compress(latent_raw, format=lzma.FORMAT_RAW,
+                                  filters=LZMA_FILTERS),
+         cc.encode_latent_section(latent_raw)),
+        ("selector", selector, cc.encode_selector_section(selector)),
+    ]
+    chosen, ids = [], []
+    for name, passthrough, ctx in sections:
+        win = len(ctx) < len(passthrough)
+        chosen.append(ctx if win else passthrough)
+        ids.append(cc.CODER_CTX if win else cc.CODER_PASSTHROUGH)
+        print(f"  {name:<8} passthrough {len(passthrough):>7,} B | "
+              f"ctx {len(ctx):>7,} B -> [{'ctx' if win else 'passthrough'}]")
+
+    container = cc.pack_container(*chosen, coder_ids=tuple(ids))
+
+    # Round trip before shipping anything.
+    s2, l2, sel2 = cc.unpack_container(container)
+    assert list(s2) == list(raws)
+    assert l2 == latent_raw
+    assert sel2 == selector
+    print("round-trip: all sections byte-exact")
+
+    write_stored_zip(args.out, "x", container)
+    size = args.out.stat().st_size
+    print(f"{args.out}: {size:,} B (member {len(container):,}; "
+          f"zip overhead {size - len(container)})")
+    print(f"vs #1 (177,136 B): {size - 177_136:+,} B "
+          f"-> rate delta {25 * (size - 177_136) / 37_545_489:+.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/hnerv_qlp/encoder/polish.py
+++ b/submissions/hnerv_qlp/encoder/polish.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Quantization-aware latent polish against the frozen #1 decoder.
+
+Freezes the PR #95 decoder (extracted from the PR #110/#112 payload) and runs
+gradient descent on the 600x28 latents ONLY, through the exact inflate chain:
+
+  decoder -> bicubic 874x1164 -> #98 channel biases (f0 R-1, f0 B-1, f1 G-1)
+  -> clamp/round (STE) -> FEC6 per-pair selector transform -> clamp/round (STE)
+  -> DistortionNet (SegNet + PoseNet) loss vs precomputed GT targets.
+
+Latents are quantized to the FIXED PR #101 uint8 grid via a straight-through
+estimator on every forward, so what we optimize is exactly what we ship.
+Because pairs are independent under a frozen decoder, the final result keeps
+the best quantized latent PER PAIR seen at any eval, not a global snapshot.
+
+Usage:
+  python polish.py --epochs 120 --lr 1.5e-3 --batch 3 --eval-every 10
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+HERE = Path(__file__).resolve().parent
+QLP_DIR = HERE.parent
+REPO = QLP_DIR.parent.parent
+FEC6_SRC = REPO / "submissions" / "hnerv_fec6_fixed_huffman_k16" / "src"
+STAGE9_SRC = REPO / "submissions" / "hnerv_stage9" / "src"
+RHNERV = REPO / "submissions" / "rhnerv_comma"
+sys.path.insert(0, str(FEC6_SRC))          # model.py (PR #95 decoder)
+sys.path.insert(0, str(STAGE9_SRC))        # data.py (targets), losses.py
+sys.path.insert(0, str(RHNERV))            # codec_ctx (latent size probe)
+sys.path.insert(0, str(HERE))
+
+from model import HNeRVDecoder                      # noqa: E402  (fec6)
+from data import precompute_targets, get_default_video_path  # noqa: E402  (stage9)
+from losses import l7_softplus_seg_loss             # noqa: E402  (stage9)
+import codec_ctx as cc                              # noqa: E402  (rhnerv)
+from latent_codec import (                          # noqa: E402
+    encode_raw_latent_payload, quantize_to_grid, dequantize)
+from frame_selector import _blue_tile               # noqa: E402  (fec6)
+
+CAMERA_H, CAMERA_W = 874, 1164
+EVAL_SIZE = (384, 512)
+N_PAIRS, LATENT_DIM = 600, 28
+ORIG_BYTES = 37_545_489
+# rhnerv_comma container: 7B header + decoder 161,104 + latent section + selector 248,
+# plus 100B zip overhead; sidecar dropped (subsumed by the polish).
+FIXED_ARCHIVE_OVERHEAD = 7 + 161_104 + 248 + 100
+
+
+def ste_round(x: torch.Tensor) -> torch.Tensor:
+    return x + (x.round() - x).detach()
+
+
+def ste_quantize_latents(lat, mins, scales):
+    codes = (lat - mins) / scales
+    codes = codes.clamp(0.0, 255.0)
+    codes = ste_round(codes)
+    return mins + codes * scales
+
+
+class SelectorApply:
+    """Differentiable FEC6 selector transforms, precompiled per pair."""
+
+    def __init__(self, selector_codes, selector_specs, device):
+        self.bias = torch.zeros(N_PAIRS, 2, 3, device=device)   # per frame RGB add
+        self.blue_amp = torch.zeros(N_PAIRS, 2, device=device)  # +R tile, -B tile
+        self.roll = [[None, None] for _ in range(N_PAIRS)]      # (dy, dx) or None
+        self.any_op = torch.zeros(N_PAIRS, dtype=torch.bool)
+        for i, code in enumerate(selector_codes.tolist()):
+            family, params, fidx = selector_specs[code]
+            if family == "identity":
+                continue
+            self.any_op[i] = True
+            if family == "rgb_bias":
+                self.bias[i, fidx] = torch.tensor(params, dtype=torch.float32,
+                                                  device=device)
+            elif family == "blue_chroma":
+                self.blue_amp[i, fidx] = float(params[0])
+            elif family == "roll":
+                dx, dy = int(params[0]), int(params[1])
+                self.roll[i][fidx] = (dy, dx)
+            else:
+                raise ValueError(family)
+        self.tile = _blue_tile(CAMERA_H, CAMERA_W, device=device,
+                               dtype=torch.float32)
+
+    def __call__(self, frames, pair_idx):
+        """frames: (B, 2, 3, H, W) post-bias, post-round. Returns same shape."""
+        out = frames
+        for b, p in enumerate(pair_idx.tolist()):
+            if not self.any_op[p]:
+                continue
+            for f in range(2):
+                delta = self.bias[p, f]
+                amp = self.blue_amp[p, f]
+                fr = out[b, f]
+                if delta.abs().sum() > 0:
+                    fr = fr + delta.view(3, 1, 1)
+                if amp != 0:
+                    fr = torch.stack([fr[0] + self.tile * amp, fr[1],
+                                      fr[2] - self.tile * amp])
+                if self.roll[p][f] is not None:
+                    dy, dx = self.roll[p][f]
+                    fr = torch.roll(fr, shifts=(dy, dx), dims=(1, 2))
+                out = out.clone() if out is frames else out
+                out[b, f] = fr
+        return out
+
+
+def decode_chain(decoder, lat_q, pair_idx, selector, *, differentiable):
+    """Exact inflate chain. lat_q: (B, 28) quantized latents (STE-attached)."""
+    B = lat_q.shape[0]
+    decoded = decoder(lat_q)                                   # (B, 2, 3, 384, 512)
+    flat = decoded.reshape(B * 2, 3, *EVAL_SIZE)
+    with torch.autocast('cuda', dtype=torch.float16, enabled=differentiable):
+        up = F.interpolate(flat, size=(CAMERA_H, CAMERA_W), mode='bicubic',
+                           align_corners=False)
+    up = up.float().reshape(B, 2, 3, CAMERA_H, CAMERA_W)
+    # PR #98 channel biases: frame0 R-1, frame0 B-1, frame1 G-1.
+    bias = torch.tensor([[-1.0, 0.0, -1.0], [0.0, -1.0, 0.0]],
+                        device=up.device).view(1, 2, 3, 1, 1)
+    up = up + bias
+    clamped = up.clamp(0, 255)
+    rounded = ste_round(clamped) if differentiable else clamped.round()
+    rounded = selector(rounded, pair_idx)
+    clamped2 = rounded.clamp(0, 255)
+    return ste_round(clamped2) if differentiable else clamped2.round()
+
+
+def scorer_forward(distortion_net, frames_b23hw, *, fp32=False):
+    """(B, 2, 3, H, W) camera-res -> (seg_logits, pose_out).
+
+    fp32=True disables autocast: the seg metric is a discrete argmax, and
+    fp16 vs fp32 disagree on borderline pixels, so selection/eval MUST be
+    fp32 to transfer to the CPU scoring axis. Training may stay fp16.
+    """
+    bhwc = frames_b23hw.permute(0, 1, 3, 4, 2)                 # (B, 2, H, W, 3)
+    with torch.autocast('cuda', dtype=torch.float16, enabled=not fp32):
+        posenet_in, segnet_in = distortion_net.preprocess_input(bhwc)
+        seg_out = distortion_net.segnet(segnet_in)
+        pose_out = distortion_net.posenet(posenet_in)
+    return seg_out.float(), {k: (v.float() if torch.is_tensor(v) else v)
+                             for k, v in pose_out.items()}
+
+
+@torch.no_grad()
+def full_eval(decoder, latents_cont, mins, scales, selector, distortion_net,
+              seg_targets_cpu, pose_targets, device, batch=8):
+    """True per-pair metrics with hard-quantized latents through the exact chain."""
+    q_codes = quantize_to_grid(latents_cont, mins, scales)
+    lat_q = dequantize(q_codes, mins, scales)
+    seg_d = torch.zeros(N_PAIRS)
+    pose_d = torch.zeros(N_PAIRS)
+    for i in range(0, N_PAIRS, batch):
+        j = min(i + batch, N_PAIRS)
+        idx = torch.arange(i, j, device=device)
+        frames = decode_chain(decoder, lat_q[i:j].to(device), idx, selector,
+                              differentiable=False)
+        seg_out, pose_out = scorer_forward(distortion_net, frames, fp32=True)
+        pred = seg_out.argmax(dim=1)                            # (B, h, w)
+        tgt = seg_targets_cpu[i:j].long().to(device)
+        seg_d[i:j] = (pred != tgt).float().flatten(1).mean(dim=1).cpu()
+        pose_d[i:j] = F.mse_loss(pose_out['pose'][:, :6], pose_targets[i:j],
+                                 reduction='none').mean(dim=1).cpu()
+    return q_codes.cpu(), seg_d, pose_d
+
+
+def latent_section_bytes(q_codes, mins, scales) -> int:
+    raw = encode_raw_latent_payload(q_codes, mins, scales)
+    return len(cc.encode_latent_section(raw))
+
+
+def projected_score(seg_mean, pose_mean, lat_bytes) -> float:
+    rate = (FIXED_ARCHIVE_OVERHEAD + lat_bytes) / ORIG_BYTES
+    return 100 * seg_mean + math.sqrt(10 * pose_mean) + 25 * rate
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--epochs", type=int, default=150)
+    ap.add_argument("--lr", type=float, default=5e-4)
+    ap.add_argument("--lr-floor", type=float, default=1e-6)
+    ap.add_argument("--batch", type=int, default=3)
+    ap.add_argument("--eval-every", type=int, default=10)
+    ap.add_argument("--ste", action="store_true",
+                    help="quantize latents (STE) during training; default is "
+                         "continuous training with quantization only at eval")
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--out", type=Path,
+                    default=QLP_DIR / "work" / "polish_run")
+    ap.add_argument("--resume", action="store_true")
+    args = ap.parse_args()
+
+    torch.manual_seed(args.seed)
+    device = torch.device("cuda")
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    payload = torch.load(QLP_DIR / "work" / "payload.pt", weights_only=False)
+    mins = payload["mins"].to(device)
+    scales = payload["scales"].to(device)
+
+    decoder = HNeRVDecoder(latent_dim=LATENT_DIM, base_channels=36,
+                           eval_size=EVAL_SIZE).to(device)
+    decoder.load_state_dict(payload["decoder_sd"])
+    decoder.eval()
+    for p in decoder.parameters():
+        p.requires_grad = False
+
+    selector = SelectorApply(payload["selector_codes"],
+                             payload["selector_specs"], device)
+
+    video_path = get_default_video_path()
+    print(f"video: {video_path}", flush=True)
+    distortion_net, seg_targets_cpu, pose_targets, _, n_pairs = (
+        precompute_targets(video_path, device))
+    assert n_pairs == N_PAIRS
+
+    latents = torch.nn.Parameter(payload["latents_eff"].clone().to(device))
+
+    # ---- Baselines --------------------------------------------------------
+    lat_bytes0 = latent_section_bytes(payload["q_codes"], mins, scales)
+    print(f"[baseline] original latent section (ctx): {lat_bytes0:,} B "
+          f"(shipping: 15,070 B + 607 B sidecar)", flush=True)
+
+    with torch.no_grad():
+        # (a) continuous sidecar-applied latents = current #1 pixels (GPU axis)
+        seg_a, pose_a = [], []
+        for i in range(0, N_PAIRS, 8):
+            j = min(i + 8, N_PAIRS)
+            idx = torch.arange(i, j, device=device)
+            frames = decode_chain(decoder, latents[i:j].detach(), idx, selector,
+                                  differentiable=False)
+            so, po = scorer_forward(distortion_net, frames, fp32=True)
+            pred = so.argmax(dim=1)
+            tgt = seg_targets_cpu[i:j].long().to(device)
+            seg_a.append((pred != tgt).float().flatten(1).mean(dim=1).cpu())
+            pose_a.append(F.mse_loss(po['pose'][:, :6], pose_targets[i:j],
+                                     reduction='none').mean(dim=1).cpu())
+        seg_a = torch.cat(seg_a); pose_a = torch.cat(pose_a)
+    print(f"[baseline a] #1 pixels (continuous+sidecar): "
+          f"seg={seg_a.mean():.8f} pose={pose_a.mean():.8f} "
+          f"(contest CPU: seg=0.00056023 pose=0.00002943)", flush=True)
+
+    q0, seg_b, pose_b = full_eval(decoder, latents.detach(), mins, scales,
+                                  selector, distortion_net, seg_targets_cpu,
+                                  pose_targets, device)
+    lb0 = latent_section_bytes(q0, mins, scales)
+    print(f"[baseline b] grid-snap of start point (no sidecar): "
+          f"seg={seg_b.mean():.8f} pose={pose_b.mean():.8f} "
+          f"lat_bytes={lb0:,} -> projected {projected_score(seg_b.mean().item(), pose_b.mean().item(), lb0):.6f}",
+          flush=True)
+
+    # Per-pair best tracking. Marginal objective: seg_i + w * pose_i with
+    # w = d(score)/d(pose_i) / d(score)/d(seg_i), linearized at current mean.
+    pose_mean = float(pose_b.mean())
+    w_pose = (10.0 / (2.0 * math.sqrt(10.0 * pose_mean))) / 100.0
+    best_metric = seg_b + w_pose * pose_b
+    best_codes = q0.clone()
+    best_seg, best_pose = seg_b.clone(), pose_b.clone()
+
+    # Global-best-epoch tracking: a NON-greedy alternative that ships one
+    # whole epoch's codes (least overfit). Scored on the true projected score.
+    gbest_proj = projected_score(seg_b.mean().item(), pose_b.mean().item(),
+                                 latent_section_bytes(q0, mins, scales))
+    gbest_codes = q0.clone()
+    gbest_seg, gbest_pose = seg_b.clone(), pose_b.clone()
+
+    opt = torch.optim.AdamW([latents], lr=args.lr, weight_decay=0.0)
+    floor = args.lr_floor / args.lr
+    sched = torch.optim.lr_scheduler.LambdaLR(
+        opt, lambda ep: max(0.5 * (1 + math.cos(math.pi * ep / args.epochs)),
+                            floor))
+
+    tau_loss = lambda logits, tgt: l7_softplus_seg_loss(
+        logits, tgt, tau=0.3, l7_threshold=1.0, l7_mult=4.0)
+
+    start_ep = 0
+    ckpt_path = args.out / "latest.pt"
+    if args.resume and ckpt_path.exists():
+        ck = torch.load(ckpt_path, map_location=device, weights_only=False)
+        latents.data.copy_(ck["latents"])
+        opt.load_state_dict(ck["opt"])
+        sched.load_state_dict(ck["sched"])
+        start_ep = ck["epoch"]
+        best_codes = ck["best_codes"]
+        best_metric = ck["best_metric"]
+        best_seg, best_pose = ck["best_seg"], ck["best_pose"]
+        print(f"resumed at epoch {start_ep}", flush=True)
+
+    t0 = time.time()
+    log_path = args.out / "log.jsonl"
+
+    for epoch in range(start_ep, args.epochs):
+        perm = torch.randperm(N_PAIRS, device=device)
+        ep_loss, nb = 0.0, 0
+        for s in range(0, N_PAIRS, args.batch):
+            idx = perm[s:s + args.batch]
+            lat_in = (ste_quantize_latents(latents[idx], mins, scales)
+                      if args.ste else latents[idx])
+            frames = decode_chain(decoder, lat_in, idx, selector,
+                                  differentiable=True)
+            seg_out, pose_out = scorer_forward(distortion_net, frames)
+            tgt = seg_targets_cpu[idx.cpu()].long().to(device)
+            seg_l = tau_loss(seg_out, tgt)
+            pose_mse = F.mse_loss(pose_out['pose'][:, :6], pose_targets[idx])
+            loss = 100.0 * seg_l + torch.sqrt(10.0 * pose_mse + 1e-12)
+            opt.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_([latents], 1.0)
+            opt.step()
+            ep_loss += loss.item(); nb += 1
+        sched.step()
+
+        if (epoch + 1) % 5 == 0 or epoch == start_ep:
+            print(f"  ep{epoch+1}/{args.epochs} loss={ep_loss/nb:.4f} "
+                  f"lr={opt.param_groups[0]['lr']:.2e} "
+                  f"({time.time()-t0:.0f}s)", flush=True)
+
+        if (epoch + 1) % args.eval_every == 0:
+            q, seg_d, pose_d = full_eval(decoder, latents.detach(), mins,
+                                         scales, selector, distortion_net,
+                                         seg_targets_cpu, pose_targets, device)
+            metric = seg_d + w_pose * pose_d
+            improved = metric < best_metric
+            best_codes[improved] = q[improved]
+            best_seg[improved] = seg_d[improved]
+            best_pose[improved] = pose_d[improved]
+            best_metric[improved] = metric[improved]
+
+            lb_cur = latent_section_bytes(q, mins, scales)
+            lb_best = latent_section_bytes(best_codes, mins, scales)
+            ps_cur = projected_score(seg_d.mean().item(), pose_d.mean().item(),
+                                     lb_cur)
+            ps_best = projected_score(best_seg.mean().item(),
+                                      best_pose.mean().item(), lb_best)
+
+            if ps_cur < gbest_proj:
+                gbest_proj = ps_cur
+                gbest_codes = q.clone()
+                gbest_seg, gbest_pose = seg_d.clone(), pose_d.clone()
+
+            print(f"    >>> ep{epoch+1}: cur seg={seg_d.mean():.8f} "
+                  f"pose={pose_d.mean():.8f} bytes={lb_cur:,} proj={ps_cur:.6f} "
+                  f"| per-pair ({int(improved.sum())}) proj={ps_best:.6f} "
+                  f"| glob-ep proj={gbest_proj:.6f}", flush=True)
+
+            with open(log_path, "a") as f:
+                f.write(json.dumps({
+                    "epoch": epoch + 1,
+                    "cur_seg": seg_d.mean().item(),
+                    "cur_pose": pose_d.mean().item(),
+                    "cur_bytes": lb_cur, "proj_cur": ps_cur,
+                    "best_seg": best_seg.mean().item(),
+                    "best_pose": best_pose.mean().item(),
+                    "best_bytes": lb_best, "proj_best": ps_best,
+                    "n_improved": int(improved.sum()),
+                }) + "\n")
+
+            torch.save({
+                "epoch": epoch + 1,
+                "latents": latents.data.cpu(),
+                "opt": opt.state_dict(), "sched": sched.state_dict(),
+                "best_codes": best_codes, "best_metric": best_metric,
+                "best_seg": best_seg, "best_pose": best_pose,
+            }, ckpt_path)
+            torch.save({"q_codes": best_codes, "mins": mins.cpu(),
+                        "scales": scales.cpu(),
+                        "seg": best_seg, "pose": best_pose},
+                       args.out / "best_codes.pt")
+            torch.save({"q_codes": gbest_codes, "mins": mins.cpu(),
+                        "scales": scales.cpu(),
+                        "seg": gbest_seg, "pose": gbest_pose},
+                       args.out / "gbest_codes.pt")
+
+    print(f"\ndone in {(time.time()-t0)/3600:.2f} h — "
+          f"final best proj={projected_score(best_seg.mean().item(), best_pose.mean().item(), latent_section_bytes(best_codes, mins, scales)):.6f}",
+          flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/hnerv_qlp/frame_selector.py
+++ b/submissions/hnerv_qlp/frame_selector.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+"""Frame-exploit selector grammar and deterministic frame-0 transforms."""
+
+from __future__ import annotations
+
+import math
+import struct
+
+import torch
+
+
+SELECTOR_MAGIC = b"FES1"
+
+# INNOVATION (sister of inflate.py INNOVATION 1): canonical 31-mode palette superset for the frame-exploit
+# selector. FEC6's active K=16 subset (see inflate.py FEC6_FIXED_K16_MODE_IDS) is drawn from this palette;
+# earlier FES1 / FEC2 / FEC3 formats use the full 31 modes. Modes are deterministic transforms on frame-0
+# (luma bias / RGB bias / blue chroma amp / roll) or frame-1 (sister modes for late-pair adjustment).
+PALETTE_MODE_IDS = (
+    "none",
+    "frame0_luma_bias_-4",
+    "frame0_luma_bias_-2",
+    "frame0_luma_bias_-1",
+    "frame0_luma_bias_+1",
+    "frame0_luma_bias_+2",
+    "frame0_luma_bias_+4",
+    "frame0_rgb_bias_p0_m1_p1",
+    "frame0_rgb_bias_p0_p1_m1",
+    "frame0_rgb_bias_p2_m1_m1",
+    "frame0_rgb_bias_m2_p1_p1",
+    "frame0_rgb_bias_p0_m2_p2",
+    "frame0_rgb_bias_p0_p2_m2",
+    "frame0_rgb_bias_p4_m2_m2",
+    "frame0_rgb_bias_m4_p2_p2",
+    "frame0_blue_chroma_amp_1",
+    "frame0_blue_chroma_amp_2",
+    "frame0_blue_chroma_amp_3",
+    "frame0_roll_dx+1_dy+0",
+    "frame0_roll_dx-1_dy+0",
+    "frame0_roll_dx+0_dy+1",
+    "frame0_roll_dx+0_dy-1",
+    "frame1_rgb_bias_p2_m1_m1",
+    "frame1_rgb_bias_m2_p1_p1",
+    "frame1_luma_bias_-1",
+    "frame1_blue_chroma_amp_3",
+    "frame1_rgb_bias_p0_m1_p1",
+    "frame1_rgb_bias_p0_p1_m1",
+    "frame1_luma_bias_+1",
+    "frame1_blue_chroma_amp_1",
+    "frame1_luma_bias_-2",
+)
+
+MODE_PARAMS: dict[str, tuple[str, tuple[int, ...]]] = {
+    "none": ("identity", ()),
+    "frame0_luma_bias_-4": ("rgb_bias", (-4, -4, -4)),
+    "frame0_luma_bias_-2": ("rgb_bias", (-2, -2, -2)),
+    "frame0_luma_bias_-1": ("rgb_bias", (-1, -1, -1)),
+    "frame0_luma_bias_+1": ("rgb_bias", (1, 1, 1)),
+    "frame0_luma_bias_+2": ("rgb_bias", (2, 2, 2)),
+    "frame0_luma_bias_+4": ("rgb_bias", (4, 4, 4)),
+    "frame0_rgb_bias_p0_m1_p1": ("rgb_bias", (0, -1, 1)),
+    "frame0_rgb_bias_p0_p1_m1": ("rgb_bias", (0, 1, -1)),
+    "frame0_rgb_bias_p2_m1_m1": ("rgb_bias", (2, -1, -1)),
+    "frame0_rgb_bias_m2_p1_p1": ("rgb_bias", (-2, 1, 1)),
+    "frame0_rgb_bias_p0_m2_p2": ("rgb_bias", (0, -2, 2)),
+    "frame0_rgb_bias_p0_p2_m2": ("rgb_bias", (0, 2, -2)),
+    "frame0_rgb_bias_p4_m2_m2": ("rgb_bias", (4, -2, -2)),
+    "frame0_rgb_bias_m4_p2_p2": ("rgb_bias", (-4, 2, 2)),
+    "frame0_blue_chroma_amp_1": ("blue_chroma", (1,)),
+    "frame0_blue_chroma_amp_2": ("blue_chroma", (2,)),
+    "frame0_blue_chroma_amp_3": ("blue_chroma", (3,)),
+    "frame0_roll_dx+1_dy+0": ("roll", (1, 0)),
+    "frame0_roll_dx-1_dy+0": ("roll", (-1, 0)),
+    "frame0_roll_dx+0_dy+1": ("roll", (0, 1)),
+    "frame0_roll_dx+0_dy-1": ("roll", (0, -1)),
+    "frame1_rgb_bias_p2_m1_m1": ("rgb_bias", (2, -1, -1)),
+    "frame1_rgb_bias_m2_p1_p1": ("rgb_bias", (-2, 1, 1)),
+    "frame1_luma_bias_-1": ("rgb_bias", (-1, -1, -1)),
+    "frame1_blue_chroma_amp_3": ("blue_chroma", (3,)),
+    "frame1_rgb_bias_p0_m1_p1": ("rgb_bias", (0, -1, 1)),
+    "frame1_rgb_bias_p0_p1_m1": ("rgb_bias", (0, 1, -1)),
+    "frame1_luma_bias_+1": ("rgb_bias", (1, 1, 1)),
+    "frame1_blue_chroma_amp_1": ("blue_chroma", (1,)),
+    "frame1_luma_bias_-2": ("rgb_bias", (-2, -2, -2)),
+}
+
+
+def _bits_per_selector(palette_size: int) -> int:
+    return max(1, math.ceil(math.log2(max(int(palette_size), 2))))
+
+
+def unpack_selector_indices(payload: bytes) -> list[int]:
+    """Decode the compact ``FES1`` little-endian bit-packed selector payload."""
+
+    if len(payload) < 10:
+        raise ValueError("selector payload truncated before header")
+    magic, n_pairs, palette_size, bits_per_index, packed_len = struct.unpack_from(
+        "<4sHBBH", payload, 0
+    )
+    if magic != SELECTOR_MAGIC:
+        raise ValueError(f"selector magic mismatch: {magic!r}")
+    expected_bits = _bits_per_selector(palette_size)
+    if bits_per_index != expected_bits:
+        raise ValueError(
+            f"selector bits_per_index={bits_per_index}, expected {expected_bits}"
+        )
+    if palette_size != len(PALETTE_MODE_IDS):
+        raise ValueError(
+            f"selector palette_size={palette_size}, runtime palette={len(PALETTE_MODE_IDS)}"
+        )
+    packed = payload[10 : 10 + packed_len]
+    if len(packed) != packed_len or len(payload) != 10 + packed_len:
+        raise ValueError("selector payload length mismatch")
+    expected_packed_len = math.ceil(n_pairs * bits_per_index / 8)
+    if packed_len != expected_packed_len:
+        raise ValueError(
+            f"selector packed_len={packed_len}, expected {expected_packed_len}"
+        )
+
+    indices: list[int] = []
+    accumulator = 0
+    nbits = 0
+    cursor = 0
+    mask = (1 << bits_per_index) - 1
+    for _ in range(n_pairs):
+        while nbits < bits_per_index:
+            if cursor >= len(packed):
+                raise ValueError("selector bitstream truncated")
+            accumulator |= int(packed[cursor]) << nbits
+            cursor += 1
+            nbits += 8
+        idx = accumulator & mask
+        accumulator >>= bits_per_index
+        nbits -= bits_per_index
+        if idx >= palette_size:
+            raise ValueError(f"selector index {idx} out of range {palette_size}")
+        indices.append(idx)
+    if accumulator != 0:
+        raise ValueError("selector bitstream has non-zero trailing bits")
+    return indices
+
+
+def _blue_tile(height: int, width: int, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    tile = torch.tensor(
+        [
+            [-1, 1, -1, 1, 1, -1, 1, -1],
+            [1, -1, 1, -1, -1, 1, -1, 1],
+            [-1, 1, 1, -1, 1, -1, -1, 1],
+            [1, -1, -1, 1, -1, 1, 1, -1],
+            [1, 1, -1, -1, 1, 1, -1, -1],
+            [-1, -1, 1, 1, -1, -1, 1, 1],
+            [1, -1, -1, 1, 1, -1, -1, 1],
+            [-1, 1, 1, -1, -1, 1, 1, -1],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    reps_h = (height + 7) // 8
+    reps_w = (width + 7) // 8
+    return tile.repeat(reps_h, reps_w)[:height, :width]
+
+
+def apply_frame0_mode(frame_chw: torch.Tensor, mode_id: str) -> torch.Tensor:
+    family, params = MODE_PARAMS[mode_id]
+    if family == "identity":
+        return frame_chw
+    out = frame_chw.clone()
+    if family == "rgb_bias":
+        delta = torch.tensor(params, dtype=out.dtype, device=out.device).view(3, 1, 1)
+        return out + delta
+    if family == "blue_chroma":
+        amp = float(params[0])
+        _channels, height, width = out.shape
+        tile = _blue_tile(height, width, device=out.device, dtype=out.dtype)
+        out[0].add_(tile * amp)
+        out[2].sub_(tile * amp)
+        return out
+    if family == "roll":
+        dx, dy = int(params[0]), int(params[1])
+        return torch.roll(out, shifts=(dy, dx), dims=(1, 2))
+    raise ValueError(f"unsupported frame-exploit mode family {family!r}")
+
+
+def apply_selector_to_frames(
+    frames_bchw: torch.Tensor,
+    selector_indices: list[int],
+    *,
+    pair_start: int,
+) -> torch.Tensor:
+    """Apply archive-packed per-pair frame-0 selector modes to a flat frame batch."""
+
+    if frames_bchw.shape[0] % 2 != 0:
+        raise ValueError("frame-exploit selector expects complete frame pairs")
+    out = frames_bchw.clone()
+    n_pairs = frames_bchw.shape[0] // 2
+    for offset in range(n_pairs):
+        pair_index = pair_start + offset
+        if pair_index >= len(selector_indices):
+            raise ValueError(
+                f"selector has {len(selector_indices)} entries; missing pair {pair_index}"
+            )
+        mode_id = PALETTE_MODE_IDS[int(selector_indices[pair_index])]
+        if mode_id == "none":
+            continue
+        frame_offset = offset * 2 + (1 if mode_id.startswith("frame1_") else 0)
+        out[frame_offset] = apply_frame0_mode(out[frame_offset], mode_id)
+    return out.clamp_(0.0, 255.0).round_()
+
+
+__all__ = [
+    "PALETTE_MODE_IDS",
+    "apply_frame0_mode",
+    "apply_selector_to_frames",
+    "unpack_selector_indices",
+]

--- a/submissions/hnerv_qlp/inflate.py
+++ b/submissions/hnerv_qlp/inflate.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Inflate the hnerv_qlp archive: PR #112's payload with the latent section
+replaced by quantization-aware-polished latents (and no sidecar).
+
+Member layout (single ZIP member `x`, ZIP_STORED):
+  [ctx container: 7-byte header | decoder section | latent section |
+   selector section]
+
+The ctx container (`codec_ctx.unpack_container`, verbatim from PR #112)
+reproduces, bit-exactly:
+  - the 7 raw decoder weight streams of PR #101 (after its Brotli layer),
+  - the raw latent payload in PR #101's grammar (polished codes, NEW),
+  - the 249-byte FEC6 selector wire payload of PR #110.
+PR #101's 607-byte latent-correction sidecar is NOT carried: the polish
+optimizes all 28 latent dims per pair directly, subsuming it.
+
+Everything from the reconstructed bytes to pixels is the EXACT #110/#112
+inflate chain -- HNeRVDecoder, 16-pair batches, bicubic 874x1164 upsample
+(align_corners=False), the #98 channel biases (frame0 R-=1, frame0 B-=1,
+frame1 G-=1), clamp(0,255).round(), then the per-pair FEC6 selector
+transforms (applied AFTER bias+clamp+round, with a final batch
+clamp_/round_), uint8, NHWC, streamed write. Device pinned to CPU.
+
+Inflate-time deps: numpy, torch, constriction (all in the harness base env).
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import codec_ctx  # type: ignore[import-not-found]
+from codec import (  # type: ignore[import-not-found]
+    BASE_CHANNELS,
+    EVAL_SIZE,
+    LATENT_DIM,
+    N_PAIRS,
+    decode_decoder_compact,
+    decode_latents_compact,
+)
+from frame_selector import _blue_tile as selector_blue_tile  # type: ignore[import-not-found]
+from model import HNeRVDecoder  # type: ignore[import-not-found]
+
+
+CAMERA_H, CAMERA_W = 874, 1164
+
+# --- FEC6 K=16 selector grammar, verbatim from fec6 inflate.py (PR #110) ---
+FEC6_FIXED_K16_MODE_IDS = (
+    "none",
+    "frame0_blue_chroma_amp_1",
+    "frame0_blue_chroma_amp_3",
+    "frame0_luma_bias_+1",
+    "frame0_luma_bias_-1",
+    "frame0_luma_bias_-2",
+    "frame0_luma_bias_-4",
+    "frame0_rgb_bias_m2_p1_p1",
+    "frame0_rgb_bias_m4_p2_p2",
+    "frame0_rgb_bias_p0_m1_p1",
+    "frame0_rgb_bias_p0_m2_p2",
+    "frame0_rgb_bias_p0_p1_m1",
+    "frame0_rgb_bias_p0_p2_m2",
+    "frame0_rgb_bias_p2_m1_m1",
+    "frame0_rgb_bias_p4_m2_m2",
+    "frame0_roll_dx+0_dy+1",
+)
+FEC6_FIXED_K16_CODE_BITS = (
+    "00",
+    "1100",
+    "01",
+    "111010",
+    "11010",
+    "111011",
+    "111100",
+    "100",
+    "111101",
+    "11011",
+    "1111110",
+    "111110",
+    "11111110",
+    "101",
+    "11100",
+    "11111111",
+)
+FEC6_FIXED_K16_DECODE = {bits: code for code, bits in enumerate(FEC6_FIXED_K16_CODE_BITS)}
+
+
+def parse_signed_token(token: str) -> int:
+    if token.startswith("p"):
+        return int(token[1:])
+    if token.startswith("m"):
+        return -int(token[1:])
+    return int(token)
+
+
+def mode_spec_from_static_mode_id(mode_id: str) -> tuple[str, tuple[int, ...], int]:
+    if mode_id == "none":
+        return ("identity", (), 0)
+    frame_index = 1 if mode_id.startswith("frame1_") else 0
+    base = mode_id.replace("frame1_", "frame0_", 1)
+    if base.startswith("frame0_luma_bias_"):
+        value = int(base.removeprefix("frame0_luma_bias_"))
+        return ("rgb_bias", (value, value, value), frame_index)
+    if base.startswith("frame0_rgb_bias_"):
+        params = tuple(parse_signed_token(part) for part in base.removeprefix("frame0_rgb_bias_").split("_"))
+        if len(params) != 3:
+            raise ValueError(f"bad RGB compact selector mode {mode_id!r}")
+        return ("rgb_bias", params, frame_index)
+    if base.startswith("frame0_blue_chroma_amp_"):
+        return ("blue_chroma", (int(base.removeprefix("frame0_blue_chroma_amp_")),), frame_index)
+    if base.startswith("frame0_roll_dx"):
+        suffix = base.removeprefix("frame0_roll_dx")
+        dx_token, dy_token = suffix.split("_dy", 1)
+        return ("roll", (int(dx_token), int(dy_token)), frame_index)
+    raise ValueError(f"unsupported static compact selector mode {mode_id!r}")
+
+
+def unpack_fec6_fixed_huffman_codes(payload: bytes, *, n_pairs: int) -> list[int]:
+    codes: list[int] = []
+    prefix = ""
+    bit_pos = 0
+    max_bits = len(payload) * 8
+    while len(codes) < n_pairs:
+        if bit_pos >= max_bits:
+            raise ValueError("FEC6 compact selector bitstream truncated")
+        bit = (payload[bit_pos // 8] >> (7 - (bit_pos % 8))) & 1
+        bit_pos += 1
+        prefix += "1" if bit else "0"
+        code = FEC6_FIXED_K16_DECODE.get(prefix)
+        if code is not None:
+            codes.append(int(code))
+            prefix = ""
+            continue
+        if len(prefix) > 8:
+            raise ValueError("FEC6 compact selector contains invalid prefix code")
+    if prefix:
+        raise ValueError("FEC6 compact selector ended mid-symbol")
+    for trailing in range(bit_pos, max_bits):
+        if (payload[trailing // 8] >> (7 - (trailing % 8))) & 1:
+            raise ValueError("FEC6 compact selector has non-zero padding bits")
+    return codes
+
+
+def unpack_fec6_selector(selector_payload: bytes) -> tuple[list[int], tuple[tuple[str, tuple[int, ...], int], ...]]:
+    if selector_payload[:4] != b"FEC6":
+        raise ValueError(f"selector magic mismatch: {selector_payload[:4]!r}")
+    n_pairs = struct.unpack_from("<H", selector_payload, 4)[0]
+    codes = unpack_fec6_fixed_huffman_codes(selector_payload[6:], n_pairs=n_pairs)
+    specs = tuple(mode_spec_from_static_mode_id(mode_id) for mode_id in FEC6_FIXED_K16_MODE_IDS)
+    return codes, specs
+
+
+def apply_dynamic_mode(frame_chw: torch.Tensor, spec: tuple[str, tuple[int, ...], int]) -> torch.Tensor:
+    family, params, _frame_index = spec
+    if family == "identity":
+        return frame_chw
+    out = frame_chw.clone()
+    if family == "rgb_bias":
+        delta = torch.tensor(params, dtype=out.dtype, device=out.device).view(3, 1, 1)
+        return out + delta
+    if family == "blue_chroma":
+        amp = float(params[0])
+        _channels, height, width = out.shape
+        tile = selector_blue_tile(height, width, device=out.device, dtype=out.dtype)
+        out[0].add_(tile * amp)
+        out[2].sub_(tile * amp)
+        return out
+    if family == "roll":
+        dx, dy = int(params[0]), int(params[1])
+        return torch.roll(out, shifts=(dy, dx), dims=(1, 2))
+    raise ValueError(f"unsupported compact selector family {family!r}")
+
+
+def apply_compact_selector_to_frames(
+    frames_bchw: torch.Tensor,
+    selector_codes: list[int],
+    selector_specs: tuple[tuple[str, tuple[int, ...], int], ...],
+    *,
+    pair_start: int,
+) -> torch.Tensor:
+    """Verbatim fec6 compact-selector apply: transforms AFTER bias+clamp+round,
+    then one final batch clamp_/round_."""
+    if frames_bchw.shape[0] % 2 != 0:
+        raise ValueError("compact selector expects complete frame pairs")
+    out = frames_bchw.clone()
+    n_pairs = frames_bchw.shape[0] // 2
+    for offset in range(n_pairs):
+        pair_index = pair_start + offset
+        if pair_index >= len(selector_codes):
+            raise ValueError(f"selector has {len(selector_codes)} entries; missing pair {pair_index}")
+        spec = selector_specs[int(selector_codes[pair_index])]
+        family, _params, frame_index = spec
+        if family == "identity":
+            continue
+        frame_offset = offset * 2 + int(frame_index)
+        out[frame_offset] = apply_dynamic_mode(out[frame_offset], spec)
+    return out.clamp_(0.0, 255.0).round_()
+
+
+def parse_member(member_bytes: bytes):
+    """ctx container (no sidecar) -> (state_dict, latents, selector codes,
+    selector specs)."""
+    if len(member_bytes) <= 7:
+        raise ValueError("member too short")
+    streams, latent_raw, selector_payload = codec_ctx.unpack_container(member_bytes)
+    decoder_sd = decode_decoder_compact(b"".join(streams))
+    latents = decode_latents_compact(latent_raw)
+    selector_codes, selector_specs = unpack_fec6_selector(selector_payload)
+    return decoder_sd, latents, selector_codes, selector_specs
+
+
+def inflate(src_bin: str, dst_raw: str) -> int:
+    decoder_sd, latents, selector_codes, selector_specs = parse_member(Path(src_bin).read_bytes())
+
+    device = torch.device("cpu")  # pinned: CPU is the leaderboard axis and the byte-stability reference
+    decoder = HNeRVDecoder(
+        latent_dim=LATENT_DIM,
+        base_channels=BASE_CHANNELS,
+        eval_size=EVAL_SIZE,
+    ).to(device)
+    decoder.load_state_dict(decoder_sd)
+    decoder.eval()
+
+    latents = latents.to(device)
+    n_pairs = N_PAIRS
+    if len(selector_codes) != n_pairs:
+        raise SystemExit(f"selector has {len(selector_codes)} pairs; archive requires exactly {n_pairs}")
+    eval_h, eval_w = EVAL_SIZE
+
+    n = 0
+    with torch.inference_mode(), open(dst_raw, "wb") as fout:
+        for i in range(0, n_pairs, 16):
+            j = min(i + 16, n_pairs)
+            batch = j - i
+            decoded = decoder(latents[i:j])
+            flat = decoded.reshape(batch * 2, 3, eval_h, eval_w)
+            up = F.interpolate(flat, size=(CAMERA_H, CAMERA_W), mode="bicubic", align_corners=False)
+            up = up.reshape(batch, 2, 3, CAMERA_H, CAMERA_W)
+            up[:, 0, 0].sub_(1.0)
+            up[:, 0, 2].sub_(1.0)
+            up[:, 1, 1].sub_(1.0)
+            rounded = up.reshape(batch * 2, 3, CAMERA_H, CAMERA_W).clamp(0, 255).round()
+            rounded = apply_compact_selector_to_frames(
+                rounded,
+                selector_codes,
+                selector_specs,
+                pair_start=i,
+            )
+            frames = rounded.to(torch.uint8).permute(0, 2, 3, 1).cpu().numpy()
+            fout.write(frames.tobytes())
+            n += batch * 2
+
+    print(f"saved {n} frames")
+    return n
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("Usage: python inflate.py <src.bin> <dst.raw>")
+    inflate(sys.argv[1], sys.argv[2])

--- a/submissions/hnerv_qlp/inflate.sh
+++ b/submissions/hnerv_qlp/inflate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+if [ -n "${PACT_PYTHON_BIN:-}" ]; then
+  PYTHON_BIN="$PACT_PYTHON_BIN"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN=python
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=python3
+else
+  echo "ERROR: neither python nor python3 is available" >&2
+  exit 127
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  BASE="${line%.*}"
+  SRC="${DATA_DIR}/x"
+  if [ ! -f "$SRC" ]; then
+    SRC="${DATA_DIR}/${BASE}.bin"
+  fi
+  DST="${OUTPUT_DIR}/${BASE}.raw"
+
+  [ ! -f "$SRC" ] && echo "ERROR: ${SRC} not found" >&2 && exit 1
+
+  printf "Inflating %s ... " "$line"
+  "$PYTHON_BIN" "$HERE/inflate.py" "$SRC" "$DST"
+done < "$FILE_LIST"

--- a/submissions/hnerv_qlp/model.py
+++ b/submissions/hnerv_qlp/model.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+"""HNeRV-style decoder: 229K params, single-video memorization.
+
+Per-frame-pair latent (28-d) -> 6 upsample stages -> 384x512 RGB pair.
+
+Each stage: Conv(in, out*4, 3x3) + PixelShuffle(2) + bilinear-skip + sin().
+Final: dilated-conv refine residual + sigmoid RGB heads (separate frame 0 and 1).
+
+Byte-identical to the HNeRV decoder published in PR #95 by @AaronLeslie138
+(https://github.com/commaai/comma_video_compression_challenge/pull/95).
+Reused unmodified; this submission performed no new training of the decoder.
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class HNeRVDecoder(nn.Module):
+    def __init__(self, latent_dim=28, base_channels=36, eval_size=(384, 512)):
+        super().__init__()
+        self.eval_size = eval_size
+        self.base_h, self.base_w = 6, 8
+        C = base_channels
+
+        # 7 stages from 6x8 to 384x512; channel taper matches HNeRV paper
+        self.channels = [C, C, C, int(C * 0.75), int(C * 0.58), int(C * 0.5), int(C * 0.5)]
+
+        self.stem = nn.Linear(latent_dim, self.channels[0] * self.base_h * self.base_w)
+
+        self.blocks = nn.ModuleList()
+        self.skips = nn.ModuleList()
+        for i in range(6):
+            in_ch = self.channels[i]
+            out_ch = self.channels[i + 1]
+            self.blocks.append(nn.Conv2d(in_ch, out_ch * 4, 3, padding=1))
+            self.skips.append(nn.Conv2d(in_ch, out_ch, 1) if in_ch != out_ch else nn.Identity())
+        self.ps = nn.PixelShuffle(2)
+
+        final_ch = self.channels[-1]
+        self.refine = nn.Sequential(
+            nn.Conv2d(final_ch, final_ch // 2, 3, padding=2, dilation=2),
+            nn.Conv2d(final_ch // 2, final_ch, 3, padding=1),
+        )
+        self.rgb_0 = nn.Conv2d(final_ch, 3, 3, padding=1)
+        self.rgb_1 = nn.Conv2d(final_ch, 3, 3, padding=1)
+
+    def forward(self, z):
+        B = z.shape[0]
+        x = self.stem(z).view(B, self.channels[0], self.base_h, self.base_w)
+        x = torch.sin(x)
+        for block, skip in zip(self.blocks, self.skips):
+            identity = F.interpolate(x, scale_factor=2, mode='bilinear', align_corners=False)
+            identity = skip(identity)
+            x = self.ps(block(x))
+            x = torch.sin(x + identity)
+        x = x + 0.1 * torch.sin(self.refine(x))
+        f0 = torch.sigmoid(self.rgb_0(x)) * 255.0
+        f1 = torch.sigmoid(self.rgb_1(x)) * 255.0
+        return torch.stack([f0, f1], dim=1)

--- a/submissions/hnerv_qlp/requirements.txt
+++ b/submissions/hnerv_qlp/requirements.txt
@@ -1,0 +1,3 @@
+torch
+numpy
+constriction


### PR DESCRIPTION
# submission name:
hnerv_qlp

# upload zipped `archive.zip`
Hosted as a release asset (`curl -L` works, SHA-256 verified):
https://github.com/Bucky789/comma_video_compression_challenge/releases/download/hnerv-qlp-v1/archive.zip

SHA-256 `ebd513903bd598b4d73d699a11c89600bd11747f27aab26737e518096675b813`, 176,525 bytes, single ZIP member `x` (ZIP_STORED).

# report.txt
```
=== Evaluation results over 600 samples ===
  Average PoseNet Distortion: 0.00003000
  Average SegNet Distortion: 0.00056085
  Submission file size: 176,525 bytes
  Original uncompressed size: 37,545,489 bytes
  Compression Rate: 0.00470163
  Final score: 100*segnet_dist + √(10*posenet_dist) + 25*rate = 0.190946
```
(`evaluate.py` prints the score to 2 dp as `0.19`; full precision is `0.190946`.)

# does your submission require gpu for evaluation (inflation)?
no — inflate is CPU-only (device pinned to CPU); deps `torch`, `numpy`, `constriction`.

# did you include the compression script? and want it to be merged?
yes — the full offline encoder is in `submissions/hnerv_qlp/encoder/` (extract → polish → pack). Happy for it to be merged.

# is this submission competitive or innovative? explain why
Both.

**Competitive:** CPU score `0.190946` vs the current #1 (`rhnerv_comma`, `0.191126`) — a margin of `-0.000180`. Local eval reproduces the #1's published metrics to ~1e-5, so the margin is real (~18x that).

| | SegNet | PoseNet | bytes | score |
|---|---|---|---|---|
| #1 `rhnerv_comma` | 0.00056023 | 0.00002943 | 177,136 | 0.191126 |
| **hnerv_qlp** | 0.00056085 | 0.00003000 | 176,525 | **0.190946** |

**Innovative:** every top submission reuses PR #95's decoder and latents; the only per-pair latent tuning attempted so far is PR #101's sidecar (one dimension, a small fixed step table). This submission generalizes that to **quantization-aware gradient descent over all 28 latent dimensions of every pair**, decoder frozen, optimized directly against SegNet/PoseNet through the exact inflate chain. The polished latents reach the #1's distortion **without** its 607-byte sidecar, so the archive is 611 bytes smaller.

# additional comments
No decoder training. Decoder weights (PR #95) and the FEC6 selector (PR #110) are reused bit-for-bit; the ctx container is PR #112's, with the latent section re-encoded and the sidecar dropped. One implementation note that mattered: the SegNet distortion is a discrete argmax, so fp16 and fp32 disagree on borderline pixels — selecting latents on an fp16 scorer overfits the GPU and regresses on the CPU axis (an fp16-selected build scored 0.191955). Evaluation and per-pair selection are done in fp32; training stays fp16 for speed. Full lineage and attribution in `submissions/hnerv_qlp/THIRD_PARTY_NOTICES.md` (PRs #95/#98/#101/#110/#112).
