### PR TITLE
veigapunk_hpac_ft submission

### DIFF
--- a/submissions/veigapunk_hpac_ft/README.md
+++ b/submissions/veigapunk_hpac_ft/README.md
@@ -1,0 +1,10 @@
+# veigapunk_hpac_ft
+
+Fine-tuned semantic renderer on top of `semantic-pose-HPAC_CPR1` (PR #130).
+
+- Same HPAC token stream and pose carrier (CPR1)
+- 800-step AdamW fine-tune of the int4 semantic renderer against SegNet CE at eval resolution
+- Archive: 191,028 bytes (−24 B vs CPR1 191,052)
+
+## Lineage
+Derived from PR #130 / fesalfayed CPR1 (semantic maps + pose carrier + integer HPAC).

--- a/submissions/veigapunk_hpac_ft/carrier_codec.py
+++ b/submissions/veigapunk_hpac_ft/carrier_codec.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Deterministic lossless coding for the semantic-pose carrier."""
+
+from __future__ import annotations
+
+import heapq
+import struct
+from collections.abc import Iterable
+
+import numpy as np
+
+
+MAGIC = b"CPR1"
+HEADER = struct.Struct("<4sII")
+BASIS_BITS = 5
+COEFF_BITS = 12
+ALPHABET_SIZE = 1 << BASIS_BITS
+MAX_HUFFMAN_LENGTH = 31
+
+
+def _bit_payload_size(bit_count: int) -> int:
+    if bit_count <= 0:
+        raise ValueError("bit count must be positive")
+    return (bit_count + 7) // 8
+
+
+def _validate_bit_payload(
+    payload: bytes | memoryview,
+    bit_count: int,
+    label: str,
+) -> None:
+    expected = _bit_payload_size(bit_count)
+    if len(payload) != expected:
+        raise ValueError(
+            f"{label} payload length mismatch: {len(payload)} != {expected}"
+        )
+    padding = expected * 8 - bit_count
+    if padding and (int(payload[-1]) & ((1 << padding) - 1)):
+        raise ValueError(f"{label} payload has nonzero padding bits")
+
+
+def _pack_bits(bits: Iterable[int]) -> tuple[bytes, int]:
+    array = np.fromiter(bits, dtype=np.uint8)
+    if array.size == 0:
+        raise ValueError("cannot pack an empty bitstream")
+    if np.any(array > 1):
+        raise ValueError("bitstream contains a value other than zero or one")
+    return (
+        np.packbits(array, bitorder="big").tobytes(),
+        int(array.size),
+    )
+
+
+def _huffman_code_lengths(values: np.ndarray) -> np.ndarray:
+    flat = np.asarray(values, dtype=np.int64).reshape(-1)
+    if flat.size == 0:
+        raise ValueError("cannot Huffman-code an empty symbol stream")
+    if flat.min() < 0 or flat.max() >= ALPHABET_SIZE:
+        raise ValueError("Huffman symbol is outside the 5-bit alphabet")
+    counts = np.bincount(flat, minlength=ALPHABET_SIZE)
+    heap: list[tuple[int, int, int | tuple]] = []
+    serial = 0
+    for symbol, count in enumerate(counts):
+        if count:
+            heap.append((int(count), serial, symbol))
+            serial += 1
+    heapq.heapify(heap)
+    if len(heap) == 1:
+        used_symbol = int(heap[0][2])
+        unused_symbol = 0 if used_symbol != 0 else 1
+        lengths = np.zeros(ALPHABET_SIZE, dtype=np.uint8)
+        lengths[used_symbol] = 1
+        lengths[unused_symbol] = 1
+        return lengths
+    while len(heap) > 1:
+        weight_a, _, node_a = heapq.heappop(heap)
+        weight_b, _, node_b = heapq.heappop(heap)
+        heapq.heappush(
+            heap,
+            (weight_a + weight_b, serial, (node_a, node_b)),
+        )
+        serial += 1
+    lengths = np.zeros(ALPHABET_SIZE, dtype=np.uint8)
+
+    def visit(node: int | tuple, depth: int) -> None:
+        if isinstance(node, int):
+            if depth <= 0 or depth > MAX_HUFFMAN_LENGTH:
+                raise ValueError("unsupported Huffman code length")
+            lengths[node] = depth
+            return
+        visit(node[0], depth + 1)
+        visit(node[1], depth + 1)
+
+    visit(heap[0][2], 0)
+    return lengths
+
+
+def _canonical_codes(
+    lengths: np.ndarray,
+) -> dict[int, tuple[int, int]]:
+    lengths = np.asarray(lengths, dtype=np.int64).reshape(-1)
+    if lengths.size != ALPHABET_SIZE:
+        raise ValueError("Huffman table must contain 32 code lengths")
+    if np.any(lengths < 0) or np.any(lengths > MAX_HUFFMAN_LENGTH):
+        raise ValueError("Huffman code length is outside the supported range")
+    entries = sorted(
+        (int(length), symbol)
+        for symbol, length in enumerate(lengths)
+        if length
+    )
+    if len(entries) < 2:
+        raise ValueError("Huffman table must contain at least two symbols")
+    code = 0
+    previous_length = 0
+    result: dict[int, tuple[int, int]] = {}
+    for length, symbol in entries:
+        code <<= length - previous_length
+        if code >= (1 << length):
+            raise ValueError("oversubscribed Huffman code lengths")
+        result[symbol] = (code, length)
+        code += 1
+        previous_length = length
+    if code != (1 << previous_length):
+        raise ValueError("incomplete Huffman code lengths")
+    return result
+
+
+def _encode_huffman(values: np.ndarray) -> tuple[np.ndarray, bytes, int]:
+    flat = np.asarray(values, dtype=np.int64).reshape(-1)
+    lengths = _huffman_code_lengths(flat)
+    codes = _canonical_codes(lengths)
+
+    def bits() -> Iterable[int]:
+        for value in flat:
+            code, length = codes[int(value)]
+            for shift in range(length - 1, -1, -1):
+                yield (code >> shift) & 1
+
+    payload, bit_count = _pack_bits(bits())
+    return lengths, payload, bit_count
+
+
+def _decode_huffman(
+    lengths: np.ndarray,
+    payload: bytes | memoryview,
+    bit_count: int,
+    symbol_count: int,
+) -> np.ndarray:
+    if symbol_count <= 0:
+        raise ValueError("Huffman symbol count must be positive")
+    _validate_bit_payload(payload, bit_count, "Huffman")
+    codes = _canonical_codes(lengths)
+    lookup = {
+        (length, code): symbol
+        for symbol, (code, length) in codes.items()
+    }
+    bits = np.unpackbits(
+        np.frombuffer(payload, dtype=np.uint8),
+        bitorder="big",
+    )[:bit_count]
+    result = np.empty(symbol_count, dtype=np.int32)
+    current = 0
+    length = 0
+    output_index = 0
+    for bit_index, bit in enumerate(bits):
+        current = (current << 1) | int(bit)
+        length += 1
+        if length > MAX_HUFFMAN_LENGTH:
+            raise ValueError("Huffman payload contains an invalid prefix")
+        symbol = lookup.get((length, current))
+        if symbol is None:
+            continue
+        result[output_index] = symbol
+        output_index += 1
+        current = 0
+        length = 0
+        if output_index == symbol_count:
+            if bit_index + 1 != bit_count:
+                raise ValueError("Huffman payload has surplus declared bits")
+            return result
+    raise ValueError("truncated Huffman payload")
+
+
+def _zigzag_signed(values: np.ndarray, bits: int) -> np.ndarray:
+    values = np.asarray(values, dtype=np.int64)
+    lower = -(1 << (bits - 1))
+    upper = (1 << (bits - 1)) - 1
+    if values.size == 0 or values.min() < lower or values.max() > upper:
+        raise ValueError(f"signed values do not fit in {bits} bits")
+    return (
+        ((values << 1) ^ (values >> 63)) & ((1 << bits) - 1)
+    ).astype(np.int32)
+
+
+def _unzigzag_unsigned(values: np.ndarray, bits: int) -> np.ndarray:
+    values = np.asarray(values, dtype=np.int64)
+    if values.size == 0 or values.min() < 0 or values.max() >= (1 << bits):
+        raise ValueError(f"unsigned values do not fit in {bits} bits")
+    decoded = (values >> 1) ^ -(values & 1)
+    return decoded.astype(np.int32)
+
+
+def _rice_bit_count(values: np.ndarray, k: int) -> int:
+    values = np.asarray(values, dtype=np.uint64).reshape(-1)
+    return int((values >> k).sum() + values.size * (k + 1))
+
+
+def _encode_rice(
+    encoded_coefficients: np.ndarray,
+) -> tuple[np.ndarray, bytes, int]:
+    values = np.asarray(encoded_coefficients, dtype=np.int64)
+    if values.ndim != 2:
+        raise ValueError("coefficient codes must have shape [frames, dimensions]")
+    if values.size == 0 or values.min() < 0 or values.max() >= (1 << COEFF_BITS):
+        raise ValueError("coefficient code is outside the 12-bit range")
+    ks: list[int] = []
+
+    def bits() -> Iterable[int]:
+        for dimension in range(values.shape[1]):
+            column = values[:, dimension]
+            _, k = min(
+                (_rice_bit_count(column, candidate), candidate)
+                for candidate in range(COEFF_BITS)
+            )
+            ks.append(k)
+            for item_value in column:
+                item = int(item_value)
+                quotient = item >> k
+                yield from (0 for _ in range(quotient))
+                yield 1
+                for shift in range(k - 1, -1, -1):
+                    yield (item >> shift) & 1
+
+    payload, bit_count = _pack_bits(bits())
+    return np.asarray(ks, dtype=np.uint8), payload, bit_count
+
+
+def _decode_rice(
+    ks: np.ndarray,
+    payload: bytes | memoryview,
+    bit_count: int,
+    frames: int,
+    dimensions: int,
+) -> np.ndarray:
+    if frames <= 0 or dimensions <= 0:
+        raise ValueError("Rice output shape must be positive")
+    ks = np.asarray(ks, dtype=np.int64).reshape(-1)
+    if ks.size != dimensions:
+        raise ValueError("Rice table does not match coefficient dimensions")
+    if np.any(ks < 0) or np.any(ks >= COEFF_BITS):
+        raise ValueError("Rice parameter is outside the supported range")
+    _validate_bit_payload(payload, bit_count, "Rice")
+    bits = np.unpackbits(
+        np.frombuffer(payload, dtype=np.uint8),
+        bitorder="big",
+    )[:bit_count]
+    cursor = 0
+    result = np.empty((frames, dimensions), dtype=np.int32)
+    for dimension, k_value in enumerate(ks):
+        k = int(k_value)
+        maximum_quotient = ((1 << COEFF_BITS) - 1) >> k
+        for frame in range(frames):
+            quotient = 0
+            while True:
+                if cursor >= bit_count:
+                    raise ValueError("truncated Rice unary code")
+                bit = int(bits[cursor])
+                cursor += 1
+                if bit:
+                    break
+                quotient += 1
+                if quotient > maximum_quotient:
+                    raise ValueError("Rice coefficient exceeds 12-bit range")
+            if cursor + k > bit_count:
+                raise ValueError("truncated Rice remainder")
+            remainder = 0
+            for _ in range(k):
+                remainder = (remainder << 1) | int(bits[cursor])
+                cursor += 1
+            value = (quotient << k) | remainder
+            if value >= (1 << COEFF_BITS):
+                raise ValueError("Rice coefficient exceeds 12-bit range")
+            result[frame, dimension] = value
+    if cursor != bit_count:
+        raise ValueError("Rice payload has surplus declared bits")
+    return result
+
+
+def encode_compact_carrier(
+    basis_scales: np.ndarray,
+    basis_codes: np.ndarray,
+    coefficient_scales: np.ndarray,
+    encoded_coefficients: np.ndarray,
+) -> bytes:
+    """Encode exact 5-bit basis codes and 12-bit delta/zigzag coefficients."""
+    basis_codes = np.asarray(basis_codes, dtype=np.int64).reshape(-1)
+    encoded_coefficients = np.asarray(encoded_coefficients, dtype=np.int64)
+    if encoded_coefficients.ndim != 2:
+        raise ValueError("coefficient codes must have shape [frames, dimensions]")
+    dimensions = encoded_coefficients.shape[1]
+    basis_scales = np.asarray(basis_scales, dtype="<f4").reshape(-1)
+    coefficient_scales = np.asarray(
+        coefficient_scales, dtype="<f4"
+    ).reshape(-1)
+    if basis_scales.size != dimensions or coefficient_scales.size != dimensions:
+        raise ValueError("carrier scale count does not match coefficient dimensions")
+
+    basis_unsigned = _zigzag_signed(basis_codes, BASIS_BITS)
+    lengths, basis_payload, basis_bit_count = _encode_huffman(basis_unsigned)
+    ks, coefficient_payload, coefficient_bit_count = _encode_rice(
+        encoded_coefficients
+    )
+    return b"".join([
+        HEADER.pack(MAGIC, basis_bit_count, coefficient_bit_count),
+        basis_scales.tobytes(),
+        coefficient_scales.tobytes(),
+        lengths.tobytes(),
+        ks.tobytes(),
+        basis_payload,
+        coefficient_payload,
+    ])
+
+
+def decode_compact_carrier(
+    blob: bytes | memoryview,
+    basis_count: int,
+    frames: int,
+    dimensions: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Decode CPR1 and return scales, signed basis, scales, encoded coefficients."""
+    if basis_count <= 0 or frames <= 0 or dimensions <= 0:
+        raise ValueError("carrier dimensions must be positive")
+    blob = memoryview(blob)
+    prefix_bytes = (
+        HEADER.size
+        + 2 * dimensions * np.dtype("<f4").itemsize
+        + ALPHABET_SIZE
+        + dimensions
+    )
+    if len(blob) < prefix_bytes:
+        raise ValueError("truncated compact carrier header")
+    magic, basis_bit_count, coefficient_bit_count = HEADER.unpack(
+        blob[:HEADER.size]
+    )
+    if magic != MAGIC:
+        raise ValueError("unsupported compact carrier magic")
+    basis_payload_bytes = _bit_payload_size(basis_bit_count)
+    coefficient_payload_bytes = _bit_payload_size(coefficient_bit_count)
+    expected_bytes = prefix_bytes + basis_payload_bytes + coefficient_payload_bytes
+    if len(blob) != expected_bytes:
+        raise ValueError(
+            f"compact carrier length mismatch: {len(blob)} != {expected_bytes}"
+        )
+
+    cursor = HEADER.size
+    scale_bytes = dimensions * np.dtype("<f4").itemsize
+    basis_scales = np.frombuffer(
+        blob[cursor:cursor + scale_bytes],
+        dtype="<f4",
+    ).copy()
+    cursor += scale_bytes
+    coefficient_scales = np.frombuffer(
+        blob[cursor:cursor + scale_bytes],
+        dtype="<f4",
+    ).copy()
+    cursor += scale_bytes
+    lengths = np.frombuffer(
+        blob[cursor:cursor + ALPHABET_SIZE],
+        dtype=np.uint8,
+    ).copy()
+    cursor += ALPHABET_SIZE
+    ks = np.frombuffer(
+        blob[cursor:cursor + dimensions],
+        dtype=np.uint8,
+    ).copy()
+    cursor += dimensions
+    basis_payload = blob[cursor:cursor + basis_payload_bytes]
+    cursor += basis_payload_bytes
+    coefficient_payload = blob[cursor:cursor + coefficient_payload_bytes]
+
+    basis_unsigned = _decode_huffman(
+        lengths,
+        basis_payload,
+        basis_bit_count,
+        basis_count,
+    )
+    basis_codes = _unzigzag_unsigned(basis_unsigned, BASIS_BITS)
+    encoded_coefficients = _decode_rice(
+        ks,
+        coefficient_payload,
+        coefficient_bit_count,
+        frames,
+        dimensions,
+    )
+    return (
+        basis_scales,
+        basis_codes,
+        coefficient_scales,
+        encoded_coefficients,
+    )

--- a/submissions/veigapunk_hpac_ft/hpac_integer.py
+++ b/submissions/veigapunk_hpac_ft/hpac_integer.py
@@ -1,0 +1,398 @@
+"""Integer-lattice HPAC student with exact cross-device inference operations."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import Optional
+
+
+def ste_round(value: torch.Tensor) -> torch.Tensor:
+    return value + (value.round() - value).detach()
+
+
+def requantize(value: torch.Tensor, shift: int, low=-127, high=127) -> torch.Tensor:
+    value = value / (1 << shift)
+    return ste_round(value).clamp(low, high)
+
+
+def integer_channel_norm(
+    value: torch.Tensor, mode: str, activation_bound: int
+) -> torch.Tensor:
+    if mode == "none":
+        return value
+    mean = ste_round(value.mean(dim=1, keepdim=True))
+    centered = value - mean
+    if mode == "center":
+        return centered.clamp(-activation_bound, activation_bound)
+    if mode != "power":
+        raise ValueError(f"unsupported integer norm mode: {mode}")
+    energy = ste_round(centered.square().mean(dim=1, keepdim=True))
+    normalized = torch.where(
+        energy < 32,
+        centered * 4,
+        torch.where(
+            energy < 128,
+            centered * 2,
+            torch.where(
+                energy < 512,
+                centered,
+                torch.where(
+                    energy < 2048,
+                    ste_round(centered / 2),
+                    ste_round(centered / 4),
+                ),
+            ),
+        ),
+    )
+    return normalized.clamp(-activation_bound, activation_bound)
+
+
+def integer_activation(value: torch.Tensor, mode: str) -> torch.Tensor:
+    if mode == "relu":
+        return F.relu(value)
+    if mode == "leaky":
+        return torch.where(value >= 0, value, ste_round(value / 4))
+    raise ValueError(f"unsupported integer activation: {mode}")
+
+
+class IntegerNormGate(nn.Module):
+    def __init__(self, channels: int, activation_bound: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(channels))
+        self.activation_bound = activation_bound
+        self.gate_bound = 16
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        normalized = integer_channel_norm(
+            value, "power", self.activation_bound
+        )
+        gate = ste_round(self.gate.clamp(0, self.gate_bound)).view(1, -1, 1, 1)
+        mixed = value * (16 - gate) + normalized * gate
+        return requantize(
+            mixed, 4, -self.activation_bound, self.activation_bound
+        )
+
+
+def patch_group_mask(kernel: int, delta: int, type_: str) -> torch.Tensor:
+    mask = torch.zeros(kernel, kernel)
+    center = (kernel - 1) // 2
+    for row in range(kernel):
+        for col in range(kernel):
+            offset = col - center + delta * (row - center)
+            if offset < 0 or (type_ == "B" and offset == 0):
+                mask[row, col] = 1
+    return mask
+
+
+class IntegerConv2d(nn.Module):
+    def __init__(self, c_in, c_out, kernel, *, padding=0, dilation=1,
+                 groups=1, mask: Optional[torch.Tensor] = None,
+                 weight_bound=127, use_weight_scales=False,
+                 exponent_min=-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(c_out, c_in // groups, kernel, kernel))
+        self.bias = nn.Parameter(torch.zeros(c_out))
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+        self.weight_bound = weight_bound
+        self.exponent_min = exponent_min
+        nn.init.normal_(self.weight, mean=0.0, std=1.5)
+        if use_weight_scales:
+            self.weight.data.mul_(8)
+            self.exponent = nn.Parameter(torch.full((c_out,), -3.0))
+        if mask is None:
+            mask = torch.ones(kernel, kernel)
+        self.register_buffer("mask", mask.view(1, 1, kernel, kernel), persistent=False)
+
+    def codes(self):
+        weight = ste_round(
+            self.weight.clamp(-self.weight_bound, self.weight_bound)
+        ) * self.mask
+        bias = ste_round(self.bias.clamp(-32768, 32767))
+        exponent = None
+        if hasattr(self, "exponent"):
+            exponent = ste_round(self.exponent.clamp(self.exponent_min, 0))
+        return weight, bias, exponent
+
+    def forward(self, value):
+        weight, bias, exponent = self.codes()
+        result = F.conv2d(
+            value, weight, None if exponent is not None else bias,
+            padding=self.padding,
+            dilation=self.dilation, groups=self.groups,
+        )
+        if exponent is not None:
+            result = result * torch.pow(2.0, exponent).view(1, -1, 1, 1)
+            result = result + bias.view(1, -1, 1, 1)
+        return result
+
+
+class IntegerLinear(nn.Module):
+    def __init__(self, c_in: int, c_out: int, weight_bound=127,
+                 use_weight_scales=False, exponent_min=-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(c_out, c_in))
+        self.bias = nn.Parameter(torch.zeros(c_out))
+        self.weight_bound = weight_bound
+        self.exponent_min = exponent_min
+        nn.init.normal_(self.weight, mean=0.0, std=1.5)
+        if use_weight_scales:
+            self.weight.data.mul_(8)
+            self.exponent = nn.Parameter(torch.full((c_out,), -3.0))
+
+    def codes(self):
+        weight = ste_round(
+            self.weight.clamp(-self.weight_bound, self.weight_bound)
+        )
+        bias = ste_round(self.bias.clamp(-32768, 32767))
+        exponent = None
+        if hasattr(self, "exponent"):
+            exponent = ste_round(self.exponent.clamp(self.exponent_min, 0))
+        return weight, bias, exponent
+
+    def forward(self, value):
+        weight, bias, exponent = self.codes()
+        result = F.linear(value, weight, None if exponent is not None else bias)
+        if exponent is not None:
+            result = result * torch.pow(2.0, exponent).view(1, -1)
+            result = result + bias.view(1, -1)
+        return result
+
+
+class IntegerHPAC(nn.Module):
+    def __init__(self, num_pairs=600, num_classes=5, patch=32,
+                 delta=2, channels=64, frame_dim=8, norm_mode="none",
+                 activation="relu", use_frame_scale=False, weight_bound=127,
+                 activation_bound=127, use_weight_scales=False,
+                 weight_exponent_min=-6, use_spm=False,
+                 use_norm_gates=False):
+        super().__init__()
+        self.num_pairs = num_pairs
+        self.num_classes = num_classes
+        self.P = patch
+        self.delta = delta
+        self.ch = channels
+        self.norm_mode = norm_mode
+        self.activation = activation
+        self.use_frame_scale = use_frame_scale
+        self.weight_bound = weight_bound
+        self.activation_bound = activation_bound
+        self.use_weight_scales = use_weight_scales
+        self.use_spm = use_spm
+        self.use_norm_gates = use_norm_gates
+        if channels * weight_bound * activation_bound + 32768 >= 2 ** 24:
+            raise ValueError("head convolution can exceed exact float32 integer range")
+        if norm_mode != "none" and activation_bound > 511:
+            raise ValueError("integer channel energy requires activation_bound <= 511")
+        self.frame_embed = nn.Embedding(num_pairs, frame_dim)
+        nn.init.normal_(self.frame_embed.weight, mean=0.0, std=2.0)
+        linear_kwargs = {
+            "weight_bound": weight_bound,
+            "use_weight_scales": use_weight_scales,
+            "exponent_min": weight_exponent_min,
+        }
+        conv_kwargs = {
+            "weight_bound": weight_bound,
+            "use_weight_scales": use_weight_scales,
+            "exponent_min": weight_exponent_min,
+        }
+        self.frame_shift = IntegerLinear(frame_dim, channels, **linear_kwargs)
+        if use_frame_scale:
+            self.frame_scale = IntegerLinear(frame_dim, channels, **linear_kwargs)
+            nn.init.zeros_(self.frame_scale.weight)
+            nn.init.zeros_(self.frame_scale.bias)
+        self.conv_a = IntegerConv2d(
+            num_classes + 2, channels, 7, padding=3,
+            mask=patch_group_mask(7, delta, "A"), **conv_kwargs,
+        )
+        self.conv_b1 = IntegerConv2d(
+            channels, channels, 5, padding=4, dilation=2, groups=channels,
+            mask=patch_group_mask(5, delta, "B"), **conv_kwargs,
+        )
+        self.conv_b2 = IntegerConv2d(
+            channels, channels, 3, padding=4, dilation=4, groups=channels,
+            mask=patch_group_mask(3, delta, "B"), **conv_kwargs,
+        )
+        self.conv_past = IntegerConv2d(
+            num_classes, channels, 3, padding=1, **conv_kwargs
+        )
+        if use_spm:
+            self.spm_dw = IntegerConv2d(
+                channels, channels, 3, padding=1, groups=channels,
+                **conv_kwargs,
+            )
+            self.spm_pw = IntegerConv2d(
+                channels, channels, 1, **conv_kwargs
+            )
+            nn.init.zeros_(self.spm_pw.weight)
+            nn.init.zeros_(self.spm_pw.bias)
+        self.head = IntegerConv2d(
+            channels, num_classes, 1, **conv_kwargs
+        )
+        if use_norm_gates:
+            self.norm_a = IntegerNormGate(channels, activation_bound)
+            self.norm_b1 = IntegerNormGate(channels, activation_bound)
+            self.norm_b2 = IntegerNormGate(channels, activation_bound)
+        self.register_buffer("_coord_cache", torch.zeros(0), persistent=False)
+
+    def frame_codes(self):
+        return ste_round(self.frame_embed.weight.clamp(-127, 127))
+
+    def _patch_coord_grid(self, batch: int, device: torch.device):
+        if self._coord_cache.numel() == 0 or self._coord_cache.device != device:
+            axis = torch.arange(self.P, device=device, dtype=torch.float32)
+            axis = axis - self.P // 2
+            yy = axis.view(1, 1, self.P, 1).expand(1, 1, self.P, self.P)
+            xx = axis.view(1, 1, 1, self.P).expand(1, 1, self.P, self.P)
+            self._coord_cache = torch.cat([yy, xx], dim=1)
+        return self._coord_cache.expand(batch, -1, -1, -1)
+
+    def _to_patches(self, value):
+        batch, channels, height, width = value.shape
+        patch_rows, patch_cols = height // self.P, width // self.P
+        value = value.view(
+            batch, channels, patch_rows, self.P, patch_cols, self.P
+        ).permute(0, 2, 4, 1, 3, 5).contiguous()
+        return value.view(batch * patch_rows * patch_cols, channels, self.P, self.P)
+
+    def _from_patches(self, value, batch: int, patch_rows: int, patch_cols: int):
+        channels = value.shape[1]
+        value = value.view(
+            batch, patch_rows, patch_cols, channels, self.P, self.P
+        ).permute(0, 3, 1, 4, 2, 5).contiguous()
+        return value.view(batch, channels, patch_rows * self.P, patch_cols * self.P)
+
+    def prepare_frame_context(self, idx, previous_raw):
+        batch, height, width = previous_raw.shape
+        patch_count = (height // self.P) * (width // self.P)
+        embedding = self.frame_codes()[idx]
+        shift = requantize(
+            self.frame_shift(embedding), 1,
+            -self.activation_bound, self.activation_bound,
+        )
+        shift = shift.view(batch, 1, self.ch, 1, 1).expand(
+            batch, patch_count, self.ch, 1, 1
+        ).reshape(batch * patch_count, self.ch, 1, 1)
+        previous_one_hot = F.one_hot(
+            previous_raw, num_classes=self.num_classes
+        ).permute(0, 3, 1, 2).float()
+        past = requantize(
+            self.conv_past(previous_one_hot), 0,
+            -self.activation_bound, self.activation_bound,
+        )
+        spm = None
+        if self.use_spm:
+            patch_rows, patch_cols = height // self.P, width // self.P
+            pooled = past.view(
+                batch, self.ch, patch_rows, self.P, patch_cols, self.P
+            ).mean(dim=(3, 5))
+            pooled = ste_round(pooled)
+            pooled = integer_activation(requantize(
+                self.spm_dw(pooled), 3,
+                -self.activation_bound, self.activation_bound,
+            ), self.activation)
+            pooled = requantize(
+                self.spm_pw(pooled), 4,
+                -self.activation_bound, self.activation_bound,
+            )
+            spm = pooled.unsqueeze(3).unsqueeze(5).expand(
+                batch, self.ch, patch_rows, self.P, patch_cols, self.P
+            ).contiguous().view(batch, self.ch, height, width)
+        scale = None
+        if self.use_frame_scale:
+            scale = requantize(self.frame_scale(embedding), 4, -8, 8)
+            scale = scale.view(batch, 1, self.ch, 1, 1).expand(
+                batch, patch_count, self.ch, 1, 1
+            ).reshape(batch * patch_count, self.ch, 1, 1)
+        return (
+            shift, self._to_patches(past), scale,
+            None if spm is None else self._to_patches(spm),
+        )
+
+    def cached_context_logits(self, current, context):
+        batch, height, width = current.shape
+        patch_rows, patch_cols = height // self.P, width // self.P
+        patch_count = patch_rows * patch_cols
+        one_hot = F.one_hot(
+            current, num_classes=self.num_classes
+        ).permute(0, 3, 1, 2).float()
+        patches = self._to_patches(one_hot)
+        coords = self._patch_coord_grid(batch * patch_count, current.device)
+        hidden = requantize(
+            self.conv_a(torch.cat([patches, coords], dim=1)), 1,
+            -self.activation_bound, self.activation_bound,
+        )
+        shift, past, scale, spm = context
+        if scale is not None:
+            hidden = requantize(
+                hidden * (16 + scale), 4,
+                -self.activation_bound, self.activation_bound,
+            )
+        if self.norm_mode == "none":
+            if self.use_norm_gates:
+                hidden = self.norm_a(hidden)
+            if spm is not None:
+                past = requantize(
+                    past + spm, 0,
+                    -self.activation_bound, self.activation_bound,
+                )
+            hidden = integer_activation(requantize(
+                hidden + shift + past, 0,
+                -self.activation_bound, self.activation_bound,
+            ), self.activation)
+            hidden = requantize(
+                self.conv_b1(hidden), 3,
+                -self.activation_bound, self.activation_bound,
+            )
+            if self.use_norm_gates:
+                hidden = self.norm_b1(hidden)
+            hidden = integer_activation(hidden, self.activation)
+            hidden = requantize(
+                self.conv_b2(hidden), 3,
+                -self.activation_bound, self.activation_bound,
+            )
+            if self.use_norm_gates:
+                hidden = self.norm_b2(hidden)
+            hidden = integer_activation(hidden, self.activation)
+            logits = requantize(self.head(hidden), 3, -32768, 32767)
+            return self._from_patches(
+                logits, batch, patch_rows, patch_cols
+            ) / 8.0
+
+        hidden = integer_channel_norm(
+            hidden, self.norm_mode, self.activation_bound
+        )
+        hidden = integer_activation(requantize(
+            hidden + shift, 0, -self.activation_bound, self.activation_bound
+        ), self.activation)
+        hidden = requantize(
+            hidden + past, 0, -self.activation_bound, self.activation_bound
+        )
+        if spm is not None:
+            hidden = requantize(
+                hidden + spm, 0,
+                -self.activation_bound, self.activation_bound,
+            )
+        hidden = integer_channel_norm(
+            requantize(
+                self.conv_b1(hidden), 3,
+                -self.activation_bound, self.activation_bound,
+            ), self.norm_mode, self.activation_bound,
+        )
+        hidden = integer_activation(hidden, self.activation)
+        hidden = integer_channel_norm(
+            requantize(
+                self.conv_b2(hidden), 3,
+                -self.activation_bound, self.activation_bound,
+            ), self.norm_mode, self.activation_bound,
+        )
+        hidden = integer_activation(hidden, self.activation)
+        logits = requantize(self.head(hidden), 3, -32768, 32767)
+        return self._from_patches(logits, batch, patch_rows, patch_cols) / 8.0
+
+    def forward(self, current, idx, previous_raw):
+        context = self.prepare_frame_context(idx, previous_raw)
+        return self.cached_context_logits(current, context)

--- a/submissions/veigapunk_hpac_ft/hpac_integer_sparse.py
+++ b/submissions/veigapunk_hpac_ft/hpac_integer_sparse.py
@@ -1,0 +1,216 @@
+"""Sparse selected-logit evaluator for IntegerHPAC arithmetic decoding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from hpac_integer import IntegerHPAC, integer_activation, requantize
+
+
+@dataclass
+class GroupPlan:
+    targets: torch.Tensor
+    h_positions: torch.Tensor
+    b1_gather: torch.Tensor
+    b2_gather: torch.Tensor
+    output_order: torch.Tensor
+
+
+def _active_offsets(module) -> list[tuple[int, int]]:
+    kernel = module.mask.shape[-1]
+    center = (kernel - 1) // 2
+    offsets = []
+    for row, col in module.mask[0, 0].nonzero(as_tuple=False).tolist():
+        offsets.append((
+            (row - center) * module.dilation,
+            (col - center) * module.dilation,
+        ))
+    return offsets
+
+
+def _positions_for_group(patch: int, delta: int, group: int):
+    return [
+        (row, col)
+        for row in range(patch)
+        for col in range(patch)
+        if col + delta * row == group
+    ]
+
+
+def _expanded_positions(positions, offsets, patch):
+    return sorted({
+        (row + dy, col + dx)
+        for row, col in positions
+        for dy, dx in offsets
+        if 0 <= row + dy < patch and 0 <= col + dx < patch
+    })
+
+
+def _gather_map(outputs, inputs, offsets, patch):
+    lookup = {position: index for index, position in enumerate(inputs)}
+    sentinel = len(inputs)
+    return [
+        [
+            lookup.get((row + dy, col + dx), sentinel)
+            if 0 <= row + dy < patch and 0 <= col + dx < patch
+            else sentinel
+            for dy, dx in offsets
+        ]
+        for row, col in outputs
+    ]
+
+
+class SparseIntegerHPAC:
+    def __init__(self, model: IntegerHPAC, height=384, width=512):
+        if model.norm_mode != "none" or model.use_norm_gates:
+            raise ValueError("sparse evaluator does not support channel normalization")
+        self.model = model
+        self.patch = model.P
+        self.patch_rows = height // model.P
+        self.patch_cols = width // model.P
+        self.patch_count = self.patch_rows * self.patch_cols
+        self.a_offsets = _active_offsets(model.conv_a)
+        self.b1_offsets = _active_offsets(model.conv_b1)
+        self.b2_offsets = _active_offsets(model.conv_b2)
+        device = next(model.parameters()).device
+        self.plans = [
+            self._build_plan(group, device)
+            for group in range((1 + model.delta) * model.P - model.delta)
+        ]
+
+    def _build_plan(self, group: int, device) -> GroupPlan:
+        targets = _positions_for_group(self.patch, self.model.delta, group)
+        b1_positions = _expanded_positions(
+            targets, self.b2_offsets, self.patch
+        )
+        h_positions = _expanded_positions(
+            b1_positions, self.b1_offsets, self.patch
+        )
+        b1_gather = _gather_map(
+            b1_positions, h_positions, self.b1_offsets, self.patch
+        )
+        b2_gather = _gather_map(
+            targets, b1_positions, self.b2_offsets, self.patch
+        )
+
+        patch_major = []
+        for patch_index in range(self.patch_count):
+            patch_row, patch_col = divmod(patch_index, self.patch_cols)
+            for row, col in targets:
+                global_row = patch_row * self.patch + row
+                global_col = patch_col * self.patch + col
+                patch_major.append(global_row * self.patch_cols * self.patch + global_col)
+        output_order = sorted(range(len(patch_major)), key=patch_major.__getitem__)
+        return GroupPlan(
+            targets=torch.tensor(targets, dtype=torch.long, device=device),
+            h_positions=torch.tensor(
+                h_positions, dtype=torch.long, device=device
+            ),
+            b1_gather=torch.tensor(
+                b1_gather, dtype=torch.long, device=device
+            ),
+            b2_gather=torch.tensor(
+                b2_gather, dtype=torch.long, device=device
+            ),
+            output_order=torch.tensor(
+                output_order, dtype=torch.long, device=device
+            ),
+        )
+
+    @staticmethod
+    def _apply_codes(value, module):
+        _, bias, exponent = module.codes()
+        if exponent is not None:
+            value = value * torch.pow(2.0, exponent).view(1, 1, -1)
+        return value + bias.view(1, 1, -1)
+
+    def _conv_a(self, inputs, positions):
+        module = self.model.conv_a
+        weight, _, _ = module.codes()
+        active = module.mask[0, 0].to(torch.bool).flatten()
+        weight = weight.flatten(2)[:, :, active].reshape(weight.shape[0], -1)
+
+        padded = F.pad(inputs, (3, 3, 3, 3))
+        row = positions[:, 0, None] + 3 + torch.tensor(
+            [dy for dy, _ in self.a_offsets], device=inputs.device
+        )
+        col = positions[:, 1, None] + 3 + torch.tensor(
+            [dx for _, dx in self.a_offsets], device=inputs.device
+        )
+        flat_index = row * (self.patch + 6) + col
+        gathered = padded.flatten(2)[:, :, flat_index]
+        features = gathered.permute(0, 2, 1, 3).reshape(
+            inputs.shape[0], positions.shape[0], -1
+        )
+        value = F.linear(features, weight)
+        return self._apply_codes(value, module)
+
+    def _depthwise(self, value, gather, module):
+        weight, _, _ = module.codes()
+        active = module.mask[0, 0].to(torch.bool).flatten()
+        weight = weight.flatten(2)[:, 0, active]
+        zero = torch.zeros(
+            value.shape[0], 1, value.shape[2],
+            dtype=value.dtype, device=value.device,
+        )
+        value = torch.cat([value, zero], dim=1)
+        gathered = value[:, gather, :]
+        result = (gathered * weight.t().view(1, 1, -1, value.shape[2])).sum(2)
+        return self._apply_codes(result, module)
+
+    @torch.no_grad()
+    def selected_logits(self, current, context, group: int):
+        plan = self.plans[group]
+        one_hot = F.one_hot(
+            current, num_classes=self.model.num_classes
+        ).permute(0, 3, 1, 2).float()
+        patches = self.model._to_patches(one_hot)
+        coords = self.model._patch_coord_grid(
+            self.patch_count, current.device
+        )
+        inputs = torch.cat([patches, coords], dim=1)
+
+        hidden = requantize(
+            self._conv_a(inputs, plan.h_positions), 1,
+            -self.model.activation_bound, self.model.activation_bound,
+        )
+        shift, past, scale, spm = context
+        if scale is not None:
+            hidden = requantize(
+                hidden * (16 + scale.squeeze(-1).transpose(1, 2)), 4,
+                -self.model.activation_bound, self.model.activation_bound,
+            )
+        position_index = (
+            plan.h_positions[:, 0] * self.patch + plan.h_positions[:, 1]
+        )
+        past = past.flatten(2)[:, :, position_index].transpose(1, 2)
+        if spm is not None:
+            past = requantize(
+                past + spm.flatten(2)[:, :, position_index].transpose(1, 2),
+                0, -self.model.activation_bound, self.model.activation_bound,
+            )
+        hidden = integer_activation(requantize(
+            hidden + shift.squeeze(-1).transpose(1, 2) + past, 0,
+            -self.model.activation_bound, self.model.activation_bound,
+        ), self.model.activation)
+
+        hidden = integer_activation(requantize(
+            self._depthwise(hidden, plan.b1_gather, self.model.conv_b1), 3,
+            -self.model.activation_bound, self.model.activation_bound,
+        ), self.model.activation)
+        hidden = integer_activation(requantize(
+            self._depthwise(hidden, plan.b2_gather, self.model.conv_b2), 3,
+            -self.model.activation_bound, self.model.activation_bound,
+        ), self.model.activation)
+
+        head = self.model.head
+        weight, _, _ = head.codes()
+        logits = F.linear(hidden, weight[:, :, 0, 0])
+        logits = requantize(
+            self._apply_codes(logits, head), 3, -32768, 32767
+        ) / 8.0
+        logits = logits.reshape(-1, self.model.num_classes)[plan.output_order]
+        return logits

--- a/submissions/veigapunk_hpac_ft/inflate.py
+++ b/submissions/veigapunk_hpac_ft/inflate.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Inflate exact semantic tokens through a compact semantic and pose renderer."""
+
+from __future__ import annotations
+
+import lzma
+import math
+import struct
+import sys
+import time
+from pathlib import Path
+
+import constriction
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from carrier_codec import MAGIC as COMPACT_CARRIER_MAGIC
+from carrier_codec import decode_compact_carrier
+from hpac_integer import IntegerHPAC
+from hpac_integer_sparse import SparseIntegerHPAC
+from integer_model_io import deserialize_integer_model
+
+
+N = 600
+NUM_CLASSES = 5
+EVAL_H, EVAL_W = 384, 512
+CAMERA_H, CAMERA_W = 874, 1164
+SEMANTIC_WIDTH = 96
+SEMANTIC_WIDTH_BY_PAYLOAD_BYTES = {30748: 80, 40252: 96}
+SEMANTIC_BLOCKS = 4
+SEMANTIC_FRAME_DIM = 8
+CARRIER_DIM = 12
+CARRIER_H, CARRIER_W = 24, 32
+CARRIER_AMPLITUDE = 64.0
+CARRIER_COEFF_BITS = 12
+CARRIER_COEFF_DELTA_ZIGZAG = True
+HPAC_PATCH = 64
+HPAC_DELTA = 2
+HPAC_CHANNELS = 64
+HPAC_FILM_DIM = 8
+HPAC_LOGIT_PRECISION = 8
+HPAC_TARGET_MODE = "raw"
+HPAC_CODER_PERFECT = False
+HPAC_HIERARCHICAL = False
+HPAC_PACKED_SCHEMA = (
+    ("conv_a.weight_q", (64, 7, 23), "i1"),
+    ("conv_a.weight_scale", (64,), "<f2"),
+    ("conv_b1.weight_q", (64, 1, 14), "i1"),
+    ("conv_b1.weight_scale", (64,), "<f2"),
+    ("conv_b2.weight_q", (64, 1, 5), "i1"),
+    ("conv_b2.weight_scale", (64,), "<f2"),
+    ("conv_past.weight_q", (64, 5, 3, 3), "i1"),
+    ("conv_past.weight_scale", (64,), "<f2"),
+    ("film_gen.weight_q", (128, 8), "i1"),
+    ("film_gen.weight_scale", (128,), "<f2"),
+    ("head.weight_q", (5, 64, 1, 1), "i1"),
+    ("head.weight_scale", (5,), "<f2"),
+    ("spm.dw.weight_q", (64, 1, 3, 3), "i1"),
+    ("spm.dw.weight_scale", (64,), "<f2"),
+    ("spm.pw.weight_q", (64, 64, 1, 1), "i1"),
+    ("spm.pw.weight_scale", (64,), "<f2"),
+    ("frame_embed.weight_q", (600, 8), "i1"),
+    ("frame_embed.weight_scale", (8,), "<f2"),
+    ("film_gen.bias", (128,), "<f2"),
+    ("conv_a.bias", (64,), "<f2"),
+    ("gn_a.scale", (64,), "<f2"),
+    ("gn_a.shift", (64,), "<f2"),
+    ("conv_b1.bias", (64,), "<f2"),
+    ("gn_b1.scale", (64,), "<f2"),
+    ("gn_b1.shift", (64,), "<f2"),
+    ("conv_b2.bias", (64,), "<f2"),
+    ("gn_b2.scale", (64,), "<f2"),
+    ("gn_b2.shift", (64,), "<f2"),
+    ("conv_past.bias", (64,), "<f2"),
+    ("spm.norm.scale", (64,), "<f2"),
+    ("spm.norm.shift", (64,), "<f2"),
+    ("spm.dw.bias", (64,), "<f2"),
+    ("spm.pw.bias", (64,), "<f2"),
+    ("head.bias", (5,), "<f2"),
+)
+
+
+def unpack_signed_int4(blob: memoryview, count: int):
+    byte_count = (count + 1) // 2
+    packed = np.frombuffer(blob[:byte_count], dtype=np.uint8)
+    values = np.empty(byte_count * 2, dtype=np.int8)
+    values[0::2] = packed & 0xF
+    values[1::2] = packed >> 4
+    values[values >= 8] -= 16
+    return torch.from_numpy(values[:count].copy()), blob[byte_count:]
+
+
+def unpack_signed_bits(blob: memoryview, count: int, bits: int):
+    if not 2 <= bits <= 8:
+        raise ValueError("signed bit unpacker supports 2 through 8 bits")
+    byte_count = (count * bits + 7) // 8
+    packed = np.frombuffer(blob[:byte_count], dtype=np.uint8)
+    bitstream = np.unpackbits(packed, bitorder="little")[:count * bits]
+    bitstream = bitstream.reshape(count, bits).astype(np.int16, copy=False)
+    shifts = (1 << np.arange(bits, dtype=np.int16))[None]
+    unsigned = (bitstream * shifts).sum(axis=1, dtype=np.int16)
+    sign = 1 << (bits - 1)
+    values = np.where(unsigned >= sign, unsigned - (1 << bits), unsigned)
+    return torch.from_numpy(values.astype(np.int8, copy=False)), blob[byte_count:]
+
+
+def unpack_signed_int12(blob: memoryview, count: int):
+    byte_count = ((count + 1) // 2) * 3
+    packed = np.frombuffer(blob[:byte_count], dtype=np.uint8).astype(np.uint16)
+    values = np.empty((byte_count // 3) * 2, dtype=np.int16)
+    values[0::2] = packed[0::3] | ((packed[1::3] & 0xF) << 8)
+    values[1::2] = (packed[1::3] >> 4) | (packed[2::3] << 4)
+    values[values >= 2048] -= 4096
+    return torch.from_numpy(values[:count].copy()), blob[byte_count:]
+
+
+class TokenBlock(nn.Module):
+    def __init__(self, width: int, frame_dim: int, dilation: int):
+        super().__init__()
+        self.dw = nn.Conv2d(
+            width, width, 3, padding=dilation, dilation=dilation, groups=width
+        )
+        self.pw = nn.Conv2d(width, width, 1)
+        self.norm = nn.GroupNorm(max(1, width // 8), width)
+        self.film = nn.Linear(frame_dim, 2 * width)
+
+    def forward(self, value: torch.Tensor, frame: torch.Tensor):
+        residual = self.norm(self.pw(self.dw(value)))
+        scale, shift = self.film(frame).chunk(2, dim=1)
+        residual = residual * (1.0 + scale[:, :, None, None])
+        residual = residual + shift[:, :, None, None]
+        return value + F.gelu(residual)
+
+
+class SemanticTokenRenderer(nn.Module):
+    def __init__(self, width: int = SEMANTIC_WIDTH):
+        super().__init__()
+        self.token_embed = nn.Embedding(NUM_CLASSES, width)
+        self.frame_embed = nn.Embedding(N, SEMANTIC_FRAME_DIM)
+        self.coord_mix = nn.Conv2d(width + 4, width, 1)
+        dilations = (1, 1, 2, 4)
+        self.blocks = nn.ModuleList([
+            TokenBlock(width, SEMANTIC_FRAME_DIM, dilation)
+            for dilation in dilations
+        ])
+        self.head = nn.Conv2d(width, 3, 3, padding=1)
+
+    @staticmethod
+    def coordinates(batch: int, device: torch.device, dtype: torch.dtype):
+        yy, xx = torch.meshgrid(
+            torch.linspace(-1.0, 1.0, EVAL_H, device=device, dtype=dtype),
+            torch.linspace(-1.0, 1.0, EVAL_W, device=device, dtype=dtype),
+            indexing="ij",
+        )
+        coords = torch.stack([xx, yy, xx.square(), yy.square()], dim=0)
+        return coords.unsqueeze(0).expand(batch, -1, -1, -1)
+
+    def forward(self, tokens: torch.Tensor, pair_idx: torch.Tensor):
+        value = self.token_embed(tokens).permute(0, 3, 1, 2)
+        value = self.coord_mix(torch.cat([
+            value, self.coordinates(value.shape[0], value.device, value.dtype)
+        ], dim=1))
+        frame = self.frame_embed(pair_idx)
+        for block in self.blocks:
+            value = block(value, frame)
+        return torch.sigmoid(self.head(F.gelu(value))) * 255.0
+
+
+def unpack_semantic(blob: bytes, template: dict[str, torch.Tensor]):
+    remaining = memoryview(blob)
+    restored = {}
+    for name, value in template.items():
+        shape = tuple(value.shape)
+        count = value.numel()
+        if value.ndim < 2:
+            byte_count = count * 2
+            array = np.frombuffer(remaining[:byte_count], dtype="<f2").copy()
+            restored[name] = torch.from_numpy(array).reshape(shape).float()
+            remaining = remaining[byte_count:]
+            continue
+        is_embedding = name.endswith("embed.weight")
+        scale_count = shape[-1] if is_embedding else shape[0]
+        scale_bytes = scale_count * 2
+        scales = torch.from_numpy(
+            np.frombuffer(remaining[:scale_bytes], dtype="<f2").copy()
+        ).float()
+        remaining = remaining[scale_bytes:]
+        codes, remaining = unpack_signed_int4(remaining, count)
+        scale_shape = [1] * len(shape)
+        scale_shape[-1 if is_embedding else 0] = scale_count
+        restored[name] = codes.reshape(shape).float() * scales.reshape(scale_shape)
+    if remaining:
+        raise ValueError("semantic payload has trailing bytes")
+    return restored
+
+
+def unpack_semantic_pose(raw: bytes):
+    if len(raw) < 8:
+        raise ValueError("truncated semantic-pose payload")
+    semantic_bytes = int.from_bytes(raw[:4], byteorder="little")
+    carrier_bytes = int.from_bytes(raw[4:8], byteorder="little")
+    if len(raw) != 8 + semantic_bytes + carrier_bytes:
+        raise ValueError("semantic-pose payload length mismatch")
+    semantic_blob = raw[8:8 + semantic_bytes]
+    carrier_blob = memoryview(raw[8 + semantic_bytes:])
+    try:
+        semantic_width = SEMANTIC_WIDTH_BY_PAYLOAD_BYTES[semantic_bytes]
+    except KeyError as error:
+        raise ValueError(
+            f"unsupported semantic payload size: {semantic_bytes} bytes"
+        ) from error
+    semantic = SemanticTokenRenderer(semantic_width)
+    semantic.load_state_dict(unpack_semantic(semantic_blob, semantic.state_dict()))
+
+    scale_bytes = CARRIER_DIM * 4
+    basis_count = CARRIER_DIM * 3 * CARRIER_H * CARRIER_W
+    coeff_count = N * CARRIER_DIM
+    if carrier_blob[:4] == COMPACT_CARRIER_MAGIC:
+        (
+            basis_scales_array,
+            basis_codes_array,
+            coeff_scales_array,
+            encoded_coefficients,
+        ) = decode_compact_carrier(
+            carrier_blob,
+            basis_count=basis_count,
+            frames=N,
+            dimensions=CARRIER_DIM,
+        )
+        basis_scales = torch.from_numpy(basis_scales_array)
+        basis_codes = torch.from_numpy(
+            basis_codes_array.astype(np.int8, copy=False)
+        )
+        coeff_scales = torch.from_numpy(coeff_scales_array)
+        coeff_codes = torch.from_numpy(
+            encoded_coefficients.astype(np.int32, copy=False)
+        )
+    else:
+        basis_scales = torch.from_numpy(
+            np.frombuffer(carrier_blob[:scale_bytes], dtype="<f4").copy()
+        )
+        carrier_blob = carrier_blob[scale_bytes:]
+        coeff_code_bytes = ((coeff_count + 1) // 2) * 3
+        basis_code_bytes = carrier_bytes - 2 * scale_bytes - coeff_code_bytes
+        if basis_code_bytes <= 0 or (basis_code_bytes * 8) % basis_count:
+            raise ValueError("carrier payload has an invalid packed basis length")
+        basis_bits = basis_code_bytes * 8 // basis_count
+        if not 4 <= basis_bits <= 8:
+            raise ValueError(f"unsupported carrier basis precision: {basis_bits}")
+        basis_codes, carrier_blob = unpack_signed_bits(
+            carrier_blob, basis_count, basis_bits
+        )
+        coeff_scales = torch.from_numpy(
+            np.frombuffer(carrier_blob[:scale_bytes], dtype="<f4").copy()
+        )
+        carrier_blob = carrier_blob[scale_bytes:]
+        if CARRIER_COEFF_BITS != 12:
+            raise ValueError("submission payload expects signed int12 coefficients")
+        coeff_codes, carrier_blob = unpack_signed_int12(carrier_blob, coeff_count)
+        if carrier_blob:
+            raise ValueError("carrier payload has trailing bytes")
+        coeff_codes = coeff_codes.reshape(N, CARRIER_DIM).to(torch.int32) & 0xFFF
+    if CARRIER_COEFF_DELTA_ZIGZAG:
+        delta = (coeff_codes >> 1) ^ -(coeff_codes & 1)
+        coeff_codes = torch.cumsum(delta, dim=0) & 0xFFF
+        coeff_codes = torch.where(
+            coeff_codes >= 0x800, coeff_codes - 0x1000, coeff_codes
+        )
+    basis = basis_codes.reshape(CARRIER_DIM, 3, CARRIER_H, CARRIER_W).float()
+    basis = basis * basis_scales[:, None, None, None]
+    coeff = coeff_codes.reshape(N, CARRIER_DIM).float() * coeff_scales[None]
+    return semantic, basis, coeff
+
+
+def patch_group_mask(kernel: int, delta: int, type_: str):
+    mask = torch.zeros(kernel, kernel)
+    center = (kernel - 1) // 2
+    for row in range(kernel):
+        for col in range(kernel):
+            group_offset = col - center + delta * (row - center)
+            if group_offset < 0 or (type_ == "B" and group_offset == 0):
+                mask[row, col] = 1.0
+    return mask
+
+
+class MaskedConv2dPG(nn.Module):
+    def __init__(self, c_in, c_out, kernel, padding=0, dilation=1,
+                 groups=1, type_="B", delta=2):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(c_out, c_in // groups, kernel, kernel))
+        self.bias = nn.Parameter(torch.empty(c_out))
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+        self.register_buffer(
+            "mask", patch_group_mask(kernel, delta, type_).view(1, 1, kernel, kernel),
+            persistent=False,
+        )
+
+    def forward(self, value):
+        return F.conv2d(
+            value, self.weight * self.mask, self.bias,
+            padding=self.padding, dilation=self.dilation, groups=self.groups,
+        )
+
+
+class ChannelNorm2d(nn.Module):
+    def __init__(self, channels: int, eps: float = 1e-5):
+        super().__init__()
+        self.scale = nn.Parameter(torch.ones(channels))
+        self.shift = nn.Parameter(torch.zeros(channels))
+        self.eps = eps
+
+    def forward(self, value):
+        mean = value.mean(dim=1, keepdim=True)
+        variance = value.var(dim=1, keepdim=True, unbiased=False)
+        value = (value - mean) / torch.sqrt(variance + self.eps)
+        return value * self.scale.view(1, -1, 1, 1) + self.shift.view(1, -1, 1, 1)
+
+
+class CausalSPM(nn.Module):
+    def __init__(self, channels: int, patch: int):
+        super().__init__()
+        self.P = patch
+        self.norm = ChannelNorm2d(channels)
+        self.dw = nn.Conv2d(channels, channels, 3, padding=1, groups=channels)
+        self.pw = nn.Conv2d(channels, channels, 1)
+
+    def forward(self, value):
+        batch, channels, height, width = value.shape
+        patch_rows, patch_cols = height // self.P, width // self.P
+        pooled = value.view(
+            batch, channels, patch_rows, self.P, patch_cols, self.P
+        ).mean(dim=(3, 5))
+        pooled = F.gelu(self.dw(self.norm(pooled)))
+        pooled = self.pw(pooled)
+        expanded = pooled.unsqueeze(3).unsqueeze(5).expand(
+            batch, channels, patch_rows, self.P, patch_cols, self.P
+        ).contiguous()
+        return expanded.view(batch, channels, height, width)
+
+
+class HPACMini(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_classes = NUM_CLASSES
+        self.P = HPAC_PATCH
+        self.delta = HPAC_DELTA
+        self.ch = HPAC_CHANNELS
+        self.frame_embed = nn.Embedding(N, HPAC_FILM_DIM)
+        self.film_gen = nn.Linear(HPAC_FILM_DIM, HPAC_CHANNELS * 2)
+        self.conv_a = MaskedConv2dPG(
+            NUM_CLASSES + 2, HPAC_CHANNELS, 7, padding=3,
+            type_="A", delta=HPAC_DELTA,
+        )
+        self.gn_a = ChannelNorm2d(HPAC_CHANNELS)
+        self.conv_b1 = MaskedConv2dPG(
+            HPAC_CHANNELS, HPAC_CHANNELS, 5, padding=4, dilation=2,
+            groups=HPAC_CHANNELS, type_="B", delta=HPAC_DELTA,
+        )
+        self.gn_b1 = ChannelNorm2d(HPAC_CHANNELS)
+        self.conv_b2 = MaskedConv2dPG(
+            HPAC_CHANNELS, HPAC_CHANNELS, 3, padding=4, dilation=4,
+            groups=HPAC_CHANNELS, type_="B", delta=HPAC_DELTA,
+        )
+        self.gn_b2 = ChannelNorm2d(HPAC_CHANNELS)
+        self.conv_past = nn.Conv2d(NUM_CLASSES, HPAC_CHANNELS, 3, padding=1)
+        self.spm = CausalSPM(HPAC_CHANNELS, HPAC_PATCH)
+        self.head = nn.Conv2d(HPAC_CHANNELS, NUM_CLASSES, 1)
+        self.register_buffer("_coord_cache", torch.zeros(0), persistent=False)
+        self._cached_P = -1
+
+    def _patch_coord_grid(self, batch: int, device: torch.device):
+        if self._cached_P != self.P or self._coord_cache.numel() == 0:
+            ys = torch.linspace(-1.0, 1.0, self.P, device=device).view(
+                1, 1, self.P, 1
+            ).expand(1, 1, self.P, self.P)
+            xs = torch.linspace(-1.0, 1.0, self.P, device=device).view(
+                1, 1, 1, self.P
+            ).expand(1, 1, self.P, self.P)
+            self._coord_cache = torch.cat([ys, xs], dim=1)
+            self._cached_P = self.P
+        return self._coord_cache.expand(batch, -1, -1, -1)
+
+    def _to_patches(self, value):
+        batch, channels, height, width = value.shape
+        patch_rows, patch_cols = height // self.P, width // self.P
+        value = value.view(
+            batch, channels, patch_rows, self.P, patch_cols, self.P
+        ).permute(0, 2, 4, 1, 3, 5).contiguous()
+        return value.view(batch * patch_rows * patch_cols, channels, self.P, self.P)
+
+    def _from_patches(self, value, batch: int, patch_rows: int, patch_cols: int):
+        channels = value.shape[1]
+        value = value.view(
+            batch, patch_rows, patch_cols, channels, self.P, self.P
+        ).permute(0, 3, 1, 4, 2, 5).contiguous()
+        return value.view(
+            batch, channels, patch_rows * self.P, patch_cols * self.P
+        )
+
+
+def reconstruct_hpac_state(packed: dict[str, torch.Tensor]):
+    state = {}
+    bases = sorted({
+        key[:-len(".weight_q")] for key in packed
+        if key.endswith(".weight_q") and key != "frame_embed.weight_q"
+    })
+    skipped = set()
+    for base in bases:
+        codes = packed[base + ".weight_q"].float()
+        masked_specs = {
+            "conv_a": (7, "A"),
+            "conv_b1": (5, "B"),
+            "conv_b2": (3, "B"),
+        }
+        if base in masked_specs:
+            kernel, type_ = masked_specs[base]
+            mask = patch_group_mask(kernel, HPAC_DELTA, type_).bool().flatten()
+            full = torch.zeros(codes.shape[0], codes.shape[1], kernel * kernel)
+            full[:, :, mask] = codes
+            codes = full.reshape(codes.shape[0], codes.shape[1], kernel, kernel)
+        scales = packed[base + ".weight_scale"].float()
+        scale_shape = [1] * codes.ndim
+        scale_shape[0] = -1
+        state[base + ".weight"] = codes * scales.view(*scale_shape)
+        skipped.update({base + ".weight_q", base + ".weight_scale"})
+    state["frame_embed.weight"] = (
+        packed["frame_embed.weight_q"].float()
+        * packed["frame_embed.weight_scale"].float()[None]
+    )
+    skipped.update({"frame_embed.weight_q", "frame_embed.weight_scale"})
+    for key, value in packed.items():
+        if key not in skipped:
+            state[key] = value.float() if torch.is_floating_point(value) else value
+    return state
+
+
+def deserialize_hpac_packed(raw: bytes):
+    packed = {}
+    offset = 0
+    for name, shape, dtype in HPAC_PACKED_SCHEMA:
+        np_dtype = np.dtype(dtype)
+        count = math.prod(shape)
+        byte_count = count * np_dtype.itemsize
+        array = np.frombuffer(raw, dtype=np_dtype, count=count, offset=offset).copy()
+        packed[name] = torch.from_numpy(array.reshape(shape))
+        offset += byte_count
+    if offset != len(raw):
+        raise ValueError("packed HPAC blob has trailing bytes")
+    return packed
+
+
+def load_hpac(raw: bytes, device: torch.device):
+    model = IntegerHPAC(
+        num_pairs=N,
+        num_classes=NUM_CLASSES,
+        patch=HPAC_PATCH,
+        delta=HPAC_DELTA,
+        channels=HPAC_CHANNELS,
+        frame_dim=HPAC_FILM_DIM,
+        norm_mode="none",
+        activation="relu",
+        use_frame_scale=True,
+        weight_bound=127,
+        activation_bound=127,
+        use_weight_scales=True,
+        weight_exponent_min=-6,
+        use_spm=True,
+        use_norm_gates=False,
+    ).eval()
+    deserialize_integer_model(model, raw)
+    return model.to(device)
+
+
+def group_masks(device: torch.device):
+    rows = torch.arange(HPAC_PATCH, device=device).view(HPAC_PATCH, 1)
+    cols = torch.arange(HPAC_PATCH, device=device).view(1, HPAC_PATCH)
+    grid = cols + HPAC_DELTA * rows
+    patch_rows, patch_cols = EVAL_H // HPAC_PATCH, EVAL_W // HPAC_PATCH
+    masks = []
+    for group in range((1 + HPAC_DELTA) * HPAC_PATCH - HPAC_DELTA):
+        local = grid == group
+        full = local[None, None].expand(
+            patch_rows, patch_cols, HPAC_PATCH, HPAC_PATCH
+        )
+        masks.append(full.permute(0, 2, 1, 3).reshape(EVAL_H, EVAL_W))
+    return masks
+
+
+def prepare_frame_context(model: HPACMini, idx, previous_raw):
+    batch, height, width = previous_raw.shape
+    patch_count = (height // model.P) * (width // model.P)
+    film = model.film_gen(model.frame_embed(idx))
+    scale, shift = film.chunk(2, dim=1)
+    scale = scale.view(batch, 1, model.ch, 1, 1).expand(
+        batch, patch_count, model.ch, 1, 1
+    ).reshape(batch * patch_count, model.ch, 1, 1)
+    shift = shift.view(batch, 1, model.ch, 1, 1).expand(
+        batch, patch_count, model.ch, 1, 1
+    ).reshape(batch * patch_count, model.ch, 1, 1)
+    previous_one_hot = F.one_hot(
+        previous_raw, num_classes=NUM_CLASSES
+    ).permute(0, 3, 1, 2).float()
+    past_full = model.conv_past(previous_one_hot)
+    past = model._to_patches(past_full)
+    spm = model._to_patches(model.spm(past_full))
+    return scale, shift, past, spm
+
+
+def cached_context_logits(model: HPACMini, current, context):
+    batch, height, width = current.shape
+    patch_rows, patch_cols = height // model.P, width // model.P
+    patch_count = patch_rows * patch_cols
+    one_hot = F.one_hot(current, num_classes=NUM_CLASSES).permute(0, 3, 1, 2).float()
+    patches = model._to_patches(one_hot)
+    coords = model._patch_coord_grid(batch * patch_count, current.device)
+    hidden = model.gn_a(model.conv_a(torch.cat([patches, coords], dim=1)))
+    scale, shift, past, spm = context
+    hidden = F.gelu(hidden * (1.0 + scale) + shift)
+    hidden = hidden + past
+    hidden = hidden + spm
+    hidden = F.gelu(model.gn_b1(model.conv_b1(hidden)))
+    hidden = F.gelu(model.gn_b2(model.conv_b2(hidden)))
+    return model._from_patches(model.head(hidden), batch, patch_rows, patch_cols)
+
+
+def probability_table(selected_logits: torch.Tensor):
+    quantized = selected_logits.mul(HPAC_LOGIT_PRECISION).round().clamp(
+        -32768, 32767
+    ).to(torch.int16)
+    logits = quantized.cpu().numpy().astype(np.float64) / HPAC_LOGIT_PRECISION
+    logits -= logits.max(axis=1, keepdims=True)
+    probabilities = np.exp(logits)
+    probabilities /= probabilities.sum(axis=1, keepdims=True)
+    return probabilities.astype(np.float32)
+
+
+def hierarchical_decode(decoder, families, table: np.ndarray):
+    top = table.argmax(axis=1).astype(np.int32)
+    rows = np.arange(len(top))
+    hit_probability = table[rows, top]
+    binary_table = np.stack([1.0 - hit_probability, hit_probability], axis=1)
+    hits = decoder.decode(families[0], binary_table.astype(np.float32))
+    symbols = top.copy()
+    miss_rows = np.flatnonzero(hits == 0)
+    if len(miss_rows) == 0:
+        return symbols
+    classes = np.arange(NUM_CLASSES, dtype=np.int32)
+    remaining = np.stack([classes[classes != top[row]] for row in miss_rows])
+    miss_table = np.take_along_axis(table[miss_rows], remaining, axis=1)
+    miss_symbols = decoder.decode(families[1], miss_table.astype(np.float32))
+    symbols[miss_rows] = remaining[np.arange(len(miss_rows)), miss_symbols]
+    return symbols
+
+
+@torch.no_grad()
+def decode_tokens(model: IntegerHPAC, blob: bytes, device: torch.device):
+    if len(blob) % np.dtype("<u4").itemsize:
+        raise ValueError("HPAC token payload length is not a multiple of four")
+    decoder = constriction.stream.queue.RangeDecoder(np.frombuffer(blob, dtype="<u4"))
+    family = constriction.stream.model.Categorical(perfect=HPAC_CODER_PERFECT)
+    hierarchical_families = (
+        constriction.stream.model.Categorical(perfect=HPAC_CODER_PERFECT),
+        constriction.stream.model.Categorical(perfect=HPAC_CODER_PERFECT),
+    )
+    masks = group_masks(device)
+    sparse = SparseIntegerHPAC(model, EVAL_H, EVAL_W)
+    tokens = torch.empty((N, EVAL_H, EVAL_W), dtype=torch.uint8)
+    previous_raw = torch.zeros((1, EVAL_H, EVAL_W), dtype=torch.long, device=device)
+    started = time.time()
+    for frame in range(N):
+        idx = torch.tensor([frame], dtype=torch.long, device=device)
+        current = torch.zeros_like(previous_raw)
+        context = model.prepare_frame_context(idx, previous_raw)
+        for group, mask in enumerate(masks):
+            selected = sparse.selected_logits(current, context, group)
+            table = probability_table(selected)
+            symbols = (
+                hierarchical_decode(decoder, hierarchical_families, table)
+                if HPAC_HIERARCHICAL
+                else decoder.decode(family, table)
+            )
+            current[0, mask] = torch.from_numpy(symbols.astype(np.int64)).to(device)
+        previous_raw = (
+            current.clone()
+            if HPAC_TARGET_MODE == "raw"
+            else (current + previous_raw) % NUM_CLASSES
+        )
+        tokens[frame].copy_(previous_raw[0].to(torch.uint8).cpu())
+        if frame == 0 or (frame + 1) % 50 == 0:
+            print(
+                f"decoded tokens {frame + 1}/{N} in {time.time() - started:.1f}s",
+                flush=True,
+            )
+    return tokens
+
+
+def normalized_basis(raw_basis: torch.Tensor):
+    basis = F.interpolate(
+        raw_basis, size=(EVAL_H, EVAL_W), mode="bicubic", align_corners=False
+    )
+    basis = basis - basis.mean(dim=(1, 2, 3), keepdim=True)
+    rms = basis.square().mean(dim=(1, 2, 3), keepdim=True).sqrt().clamp_min(1e-5)
+    return basis / rms
+
+
+@torch.no_grad()
+def render_video(semantic, basis, coeff, tokens, destination: Path, device):
+    semantic = semantic.eval().to(device)
+    basis = normalized_basis(basis.to(device))
+    coeff = coeff.to(device)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    output = np.memmap(
+        destination, mode="w+", dtype=np.uint8,
+        shape=(N * 2, CAMERA_H, CAMERA_W, 3),
+    )
+    started = time.time()
+    semantic_batch = 8 if device.type == "cuda" else 1
+    for start in range(0, N, semantic_batch):
+        end = min(start + semantic_batch, N)
+        idx = torch.arange(start, end, device=device)
+        current_tokens = tokens[start:end].long().to(device)
+        master_eval = semantic(current_tokens, idx)
+        master = F.interpolate(
+            master_eval, size=(CAMERA_H, CAMERA_W),
+            mode="bilinear", align_corners=False,
+        ).clamp(0.0, 255.0).round()
+        master_np = master.to(torch.uint8).permute(0, 2, 3, 1).cpu().numpy()
+        for offset in range(end - start):
+            output[2 * (start + offset) + 1] = master_np[offset]
+        if end % 50 == 0 or end == N:
+            print(f"rendered masters {end}/{N} in {time.time() - started:.1f}s", flush=True)
+
+    pose_batch = 64 if device.type == "cuda" else 1
+    for start in range(0, N, pose_batch):
+        end = min(start + pose_batch, N)
+        carrier = torch.einsum("bk,kchw->bchw", coeff[start:end], basis)
+        carrier = carrier / math.sqrt(CARRIER_DIM)
+        slave_eval = (127.5 + CARRIER_AMPLITUDE * carrier).clamp(
+            0.0, 255.0
+        ).round()
+        slave = F.interpolate(
+            slave_eval, size=(CAMERA_H, CAMERA_W),
+            mode="bicubic", align_corners=False,
+        ).clamp(0.0, 255.0).round()
+        slave_np = slave.to(torch.uint8).permute(0, 2, 3, 1).cpu().numpy()
+        for offset in range(end - start):
+            output[2 * (start + offset)] = slave_np[offset]
+        if end % 64 == 0 or end == N:
+            print(f"rendered carriers {end}/{N} in {time.time() - started:.1f}s", flush=True)
+    output.flush()
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: inflate.py <archive-dir> <base> <destination.raw>")
+    data_dir = Path(sys.argv[1])
+    base = sys.argv[2]
+    destination = Path(sys.argv[3])
+    if base != "0":
+        raise ValueError(f"unsupported public video: {base}")
+    if not torch.cuda.is_available():
+        raise RuntimeError("semantic_pose_landslide requires the official GPU rail")
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    device = torch.device("cuda")
+    payload = (data_dir / "p").read_bytes()
+    if len(payload) < 4:
+        raise ValueError("combined payload is truncated before the model length")
+    models_bytes = struct.unpack_from("<I", payload)[0]
+    if len(payload) <= 4 + models_bytes:
+        raise ValueError("combined payload is truncated")
+    models_raw = lzma.decompress(payload[4:4 + models_bytes])
+    if len(models_raw) < 8:
+        raise ValueError("model bundle is truncated before semantic-pose lengths")
+    semantic_bytes, carrier_bytes = struct.unpack_from("<II", models_raw)
+    semantic_pose_bytes = 8 + semantic_bytes + carrier_bytes
+    if semantic_pose_bytes > len(models_raw):
+        raise ValueError("semantic-pose lengths exceed the model bundle")
+    semantic, basis, coeff = unpack_semantic_pose(
+        models_raw[:semantic_pose_bytes]
+    )
+    hpac = load_hpac(models_raw[semantic_pose_bytes:], device)
+    tokens = decode_tokens(hpac, payload[4 + models_bytes:], device)
+    del hpac
+    torch.cuda.empty_cache()
+    render_video(semantic, basis, coeff, tokens, destination, device)
+    print(f"wrote {destination} ({destination.stat().st_size} bytes)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/veigapunk_hpac_ft/inflate.sh
+++ b/submissions/veigapunk_hpac_ft/inflate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="$1"
+OUTPUT_DIR="$2"
+FILE_LIST="$3"
+
+mkdir -p "$OUTPUT_DIR"
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  base="${line%.*}"
+  python "${HERE}/inflate.py" "$DATA_DIR" "$base" "${OUTPUT_DIR}/${base}.raw"
+done < "$FILE_LIST"

--- a/submissions/veigapunk_hpac_ft/integer_model_io.py
+++ b/submissions/veigapunk_hpac_ft/integer_model_io.py
@@ -1,0 +1,143 @@
+"""Fixed-schema loader for the deployed exact-integer entropy model."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from hpac_integer import IntegerConv2d, IntegerLinear
+
+
+SELF_COMPRESSED_MAGIC = b"IHS1"
+COMPRESSIBLE_TYPES = (IntegerConv2d, IntegerLinear)
+
+
+def _unpack_nibbles(raw: memoryview, count: int):
+    byte_count = (count + 1) // 2
+    packed = np.frombuffer(raw[:byte_count], dtype=np.uint8)
+    values = np.empty(byte_count * 2, dtype=np.uint8)
+    values[0::2] = packed & 0xF
+    values[1::2] = packed >> 4
+    return values[:count].copy(), raw[byte_count:]
+
+
+def _weight_rows(module, weight):
+    if isinstance(module, IntegerConv2d):
+        mask = module.mask.to(torch.bool).expand_as(weight)
+        return [weight[index][mask[index]] for index in range(weight.shape[0])]
+    return [weight[index].reshape(-1) for index in range(weight.shape[0])]
+
+
+def _restore_weight_row(module, parameter, index, values):
+    values = torch.from_numpy(values.astype(np.float32))
+    if isinstance(module, IntegerConv2d):
+        mask = module.mask.to(torch.bool).expand_as(parameter)[index]
+        parameter[index].zero_()
+        parameter[index][mask] = values
+    else:
+        parameter[index].copy_(values.reshape(parameter[index].shape))
+
+
+def _deserialize_self_compressed(model, raw: bytes) -> None:
+    view = memoryview(raw)[len(SELF_COMPRESSED_MAGIC):]
+    modules = [
+        module for module in model.modules()
+        if isinstance(module, COMPRESSIBLE_TYPES)
+    ]
+    channel_count = sum(module.weight.shape[0] for module in modules)
+    depths, view = _unpack_nibbles(view, channel_count)
+
+    total_weight_bits = 0
+    depth_offset = 0
+    for module in modules:
+        module_depths = depths[depth_offset:depth_offset + module.weight.shape[0]]
+        row_counts = [row.numel() for row in _weight_rows(module, module.weight)]
+        total_weight_bits += sum(
+            int(bits) * count for bits, count in zip(module_depths, row_counts)
+        )
+        depth_offset += module.weight.shape[0]
+    weight_bytes = (total_weight_bits + 7) // 8
+    packed = np.frombuffer(view[:weight_bytes], dtype=np.uint8)
+    weight_bits = np.unpackbits(packed, bitorder="little")[:total_weight_bits]
+    view = view[weight_bytes:]
+
+    bit_offset = 0
+    depth_offset = 0
+    with torch.no_grad():
+        for module in modules:
+            parameter = module.weight
+            module_depths = depths[
+                depth_offset:depth_offset + parameter.shape[0]
+            ]
+            for index, (bits, template) in enumerate(zip(
+                module_depths, _weight_rows(module, parameter)
+            )):
+                count = template.numel()
+                bits = int(bits)
+                if bits:
+                    count_bits = count * bits
+                    rows = weight_bits[
+                        bit_offset:bit_offset + count_bits
+                    ].reshape(count, bits).astype(np.int16)
+                    unsigned = (
+                        rows * (1 << np.arange(bits, dtype=np.int16))
+                    ).sum(axis=1, dtype=np.int16)
+                    sign = 1 << (bits - 1)
+                    values = np.where(
+                        unsigned >= sign, unsigned - (1 << bits), unsigned
+                    ).astype(np.int16)
+                    bit_offset += count_bits
+                else:
+                    values = np.zeros(count, dtype=np.int16)
+                _restore_weight_row(module, parameter, index, values)
+            depth_offset += parameter.shape[0]
+
+        module_by_name = dict(model.named_modules())
+        for name, parameter in model.named_parameters():
+            module_name, field = name.rsplit(".", 1)
+            module = module_by_name[module_name]
+            if field == "weight" and isinstance(module, COMPRESSIBLE_TYPES):
+                continue
+            dtype = np.dtype("<i2" if field == "bias" else "i1")
+            byte_count = parameter.numel() * dtype.itemsize
+            value = np.frombuffer(
+                view[:byte_count], dtype=dtype, count=parameter.numel()
+            ).copy().reshape(parameter.shape)
+            parameter.copy_(torch.from_numpy(value.astype(np.float32)))
+            view = view[byte_count:]
+    if bit_offset != total_weight_bits or len(view):
+        raise ValueError("self-compressed integer model has trailing data")
+
+
+def deserialize_integer_model(model, raw: bytes) -> None:
+    if raw.startswith(SELF_COMPRESSED_MAGIC):
+        _deserialize_self_compressed(model, raw)
+        return
+    modules = dict(model.named_modules())
+    offset = 0
+    with torch.no_grad():
+        for name, parameter in model.named_parameters():
+            module_name, field = name.rsplit(".", 1)
+            module = modules[module_name]
+            masked_weight = field == "weight" and isinstance(module, IntegerConv2d)
+            count = (
+                int(module.mask.to(torch.bool).expand_as(parameter).sum().item())
+                if masked_weight else parameter.numel()
+            )
+            dtype = np.dtype("<i2" if field == "bias" else "i1")
+            byte_count = count * dtype.itemsize
+            value = np.frombuffer(
+                raw, dtype=dtype, count=count, offset=offset
+            ).copy()
+            if masked_weight:
+                restored = torch.zeros_like(parameter)
+                mask = module.mask.to(torch.bool).expand_as(parameter)
+                restored[mask] = torch.from_numpy(value.astype(np.float32))
+            else:
+                restored = torch.from_numpy(
+                    value.reshape(parameter.shape).astype(np.float32)
+                )
+            parameter.copy_(restored)
+            offset += byte_count
+    if offset != len(raw):
+        raise ValueError(f"integer model has {len(raw) - offset} trailing bytes")

--- a/submissions/veigapunk_hpac_ft/meta.json
+++ b/submissions/veigapunk_hpac_ft/meta.json
@@ -1,0 +1,8 @@
+{
+  "semantic_bytes": 40252,
+  "carrier_bytes": 23054,
+  "models_xz": 73944,
+  "payload": 190928,
+  "archive": 191028,
+  "steps": 800
+}


### PR DESCRIPTION
# submission name:

`veigapunk_hpac_ft`

# upload zipped `archive.zip`

[Download archive.zip](https://github.com/VeigaPunk/comma_video_compression_challenge/releases/download/veigapunk-hpac-ft-v1/archive.zip)

- Size: 191,028 bytes
- SHA-256: see release asset

# report.txt

Local RTX 5070 evaluation of parent CPR1 lineage scored **0.17** (pose≈0.00001948, seg≈0.00029598, 191052 B). This submission fine-tunes the semantic renderer and shrinks the archive by 24 B. Official T4 evaluation requested.

```
=== Evaluation results (parent CPR1, local CUDA) ===
  Average PoseNet Distortion: 0.00001948
  Average SegNet Distortion: 0.00029598
  Submission file size: 191,052 bytes
  Compression Rate: 0.00508855
  Final score: 0.17
```

FT archive is 191,028 B (rate 0.00508791). Full official GPU eval pending for FT metrics.

# does your submission require gpu for evaluation (inflation)?

Yes — please use `linux-nvidia-t4` / CUDA.

# did you include the compression script? and want it to be merged?

Inflate path included. Compression is fine-tune + repack of PR #130 lineage (semantic-pose-HPAC_CPR1).

# is this submission competitive or innovative? explain why

Competitive attempt: 800-step SegNet-CE fine-tune of the CPR1 semantic renderer + lossless xz repack (−24 B). Lineage from PR #130.

# additional comments

Please run official T4 evaluation.